### PR TITLE
Add workflow to fix collaborator handles in release notes

### DIFF
--- a/.github/workflows/fix-release-notes.yml
+++ b/.github/workflows/fix-release-notes.yml
@@ -19,8 +19,8 @@ jobs:
         run: |
           body=$(gh release view "$TAG" --json body --jq '.body')
           # Replace [@handle](https://github.com/handle) with just @handle
-          updated=$(echo "$body" | sed -E 's/\[@([a-zA-Z0-9_-]+)\]\(https:\/\/github\.com\/\1\)/@\1/g')
+          updated=$(printf '%s' "$body" | sed -E 's/\[@([a-zA-Z0-9_-]+)\]\(https:\/\/github\.com\/\1\)/@\1/g')
           if [ "$body" != "$updated" ]; then
             echo "Updating release notes for $TAG"
-            gh release edit "$TAG" --notes "$updated"
+            printf '%s' "$updated" | gh release edit "$TAG" --notes-file -
           fi


### PR DESCRIPTION
Changesets generates markdown links for GitHub handles (e.g. [@user](https://github.com/user)) which prevents GitHub from recognizing them as mentions and showing contributors below the release. This workflow triggers on release creation and replaces those links with raw @ handles.