### PR TITLE
Improve MySQL query performance and SQL log pagination

### DIFF
--- a/.changeset/flat-doors-boil.md
+++ b/.changeset/flat-doors-boil.md
@@ -1,0 +1,19 @@
+---
+"blocky-ui": patch
+---
+
+Dramatically improve MySQL-backed dashboard performance on large query log tables
+
+Statistics queries that could take tens of seconds now complete in sub-second time in typical cases. This makes the initial dashboard load, top domains, top clients, queries-over-time, and adjacent page prefetches much faster when using `QUERY_LOG_TYPE=mysql`.
+
+#### Before and After
+
+Measured locally against a large MySQL query log table:
+
+| Query | Before | After |
+| --- | ---: | ---: |
+| Top Clients | ~60s | ~500ms |
+| Top Domains | ~20s | ~650ms |
+| Queries Over Time | ~6s | ~400ms |
+| Overview | ~5s | ~500ms |
+| Initial dashboard data load | ~70s | ~1s |

--- a/src/components/dashboard/query-logs/query-logs.tsx
+++ b/src/components/dashboard/query-logs/query-logs.tsx
@@ -17,7 +17,7 @@ import {
 } from "~/components/ui/tooltip";
 import { Switch } from "~/components/ui/switch";
 import { Label } from "~/components/ui/label";
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
 import { DataTable } from "./data-table";
 import { columns } from "./columns";
 import {
@@ -38,6 +38,7 @@ import {
   type QueryLogFilter,
 } from "./query-log-filter-combobox";
 import { toast } from "sonner";
+import { usePrefetchAdjacentPages } from "~/hooks/use-prefetch-adjacent-pages";
 
 export function QueryLogs() {
   const [filter, setFilter] = useState<QueryLogFilter>(null);
@@ -62,17 +63,21 @@ export function QueryLogs() {
     setPageIndex(0);
   };
 
+  const search = filter?.type === "domain" ? filter.value : undefined;
+  const client = filter?.type === "client" ? filter.value : undefined;
+  const responseType = isResponseType(responseTypeFilter)
+    ? responseTypeFilter
+    : undefined;
+  const questionType = isDnsRecordType(questionTypeFilter)
+    ? questionTypeFilter
+    : undefined;
   const searchParams = {
-    search: filter?.type === "domain" ? filter.value : undefined,
-    client: filter?.type === "client" ? filter.value : undefined,
+    search,
+    client,
     limit: pageSize,
     offset: pageIndex * pageSize,
-    responseType: isResponseType(responseTypeFilter)
-      ? responseTypeFilter
-      : undefined,
-    questionType: isDnsRecordType(questionTypeFilter)
-      ? questionTypeFilter
-      : undefined,
+    responseType,
+    questionType,
   };
 
   const {
@@ -110,19 +115,21 @@ export function QueryLogs() {
   const pageCount = Math.ceil((queryLogsData?.totalCount ?? 0) / pageSize);
   const utils = api.useUtils();
 
-  if (pageIndex > 0) {
-    void utils.blocky.getQueryLogs.prefetch({
-      ...searchParams,
-      offset: (pageIndex - 1) * pageSize,
-    });
-  }
-
-  if (pageIndex < pageCount - 1) {
-    void utils.blocky.getQueryLogs.prefetch({
-      ...searchParams,
-      offset: (pageIndex + 1) * pageSize,
-    });
-  }
+  usePrefetchAdjacentPages({
+    enabled: !isFetchingLogs && queryLogsData !== undefined,
+    currentPage: pageIndex,
+    totalPages: pageCount,
+    prefetchPage: (targetPage) => {
+      void utils.blocky.getQueryLogs.prefetch({
+        search,
+        client,
+        limit: pageSize,
+        offset: targetPage * pageSize,
+        responseType,
+        questionType,
+      });
+    },
+  });
 
   return (
     <Card>

--- a/src/components/dashboard/statistics/top-clients-table.tsx
+++ b/src/components/dashboard/statistics/top-clients-table.tsx
@@ -17,6 +17,7 @@ import { FloatingCard } from "~/components/ui/floating-card";
 import { cn, formatCount } from "~/lib/utils";
 import { api } from "~/trpc/react";
 import { type TimeRange } from "~/lib/constants";
+import { usePrefetchAdjacentPages } from "~/hooks/use-prefetch-adjacent-pages";
 
 interface TopClientsTableProps {
   range: TimeRange;
@@ -43,26 +44,22 @@ export function TopClientsTable({ range, limit }: TopClientsTableProps) {
   const totalCount = data?.totalCount ?? 0;
   const totalPages = Math.ceil(totalCount / limit);
   const showPagination = totalPages > 1;
-
   const utils = api.useUtils();
 
-  if (page > 0) {
-    void utils.stats.topClients.prefetch({
-      range,
-      limit,
-      offset: (page - 1) * limit,
-      filter,
-    });
-  }
+  usePrefetchAdjacentPages({
+    enabled: !isFetching && data !== undefined,
+    currentPage: page,
+    totalPages,
+    prefetchPage: (targetPage) => {
+      void utils.stats.topClients.prefetch({
+        range,
+        limit,
+        offset: targetPage * limit,
+        filter,
+      });
+    },
+  });
 
-  if (page < totalPages - 1) {
-    void utils.stats.topClients.prefetch({
-      range,
-      limit,
-      offset: (page + 1) * limit,
-      filter,
-    });
-  }
   const maxTotal = items[0]?.total ?? 0;
 
   const handleFilterChange = (newFilter: FilterType) => {

--- a/src/components/dashboard/statistics/top-domains-table.tsx
+++ b/src/components/dashboard/statistics/top-domains-table.tsx
@@ -17,6 +17,7 @@ import { FloatingCard } from "~/components/ui/floating-card";
 import { cn, formatCount } from "~/lib/utils";
 import { api } from "~/trpc/react";
 import { type TimeRange } from "~/lib/constants";
+import { usePrefetchAdjacentPages } from "~/hooks/use-prefetch-adjacent-pages";
 
 interface TopDomainsTableProps {
   range: TimeRange;
@@ -43,26 +44,22 @@ export function TopDomainsTable({ range, limit }: TopDomainsTableProps) {
   const totalCount = data?.totalCount ?? 0;
   const totalPages = Math.ceil(totalCount / limit);
   const showPagination = totalPages > 1;
-
   const utils = api.useUtils();
 
-  if (page > 0) {
-    void utils.stats.topDomains.prefetch({
-      range,
-      limit,
-      offset: (page - 1) * limit,
-      filter,
-    });
-  }
+  usePrefetchAdjacentPages({
+    enabled: !isFetching && data !== undefined,
+    currentPage: page,
+    totalPages,
+    prefetchPage: (targetPage) => {
+      void utils.stats.topDomains.prefetch({
+        range,
+        limit,
+        offset: targetPage * limit,
+        filter,
+      });
+    },
+  });
 
-  if (page < totalPages - 1) {
-    void utils.stats.topDomains.prefetch({
-      range,
-      limit,
-      offset: (page + 1) * limit,
-      filter,
-    });
-  }
   const maxCount = items[0]?.count ?? 0;
 
   const handleFilterChange = (newFilter: FilterType) => {

--- a/src/hooks/use-filter-suggestions.ts
+++ b/src/hooks/use-filter-suggestions.ts
@@ -30,12 +30,12 @@ export function useFilterSuggestions(
   const hasSearch = debouncedSearch.length > 0;
 
   const { data: topDomains } = api.stats.topDomains.useQuery(
-    { range, limit: 5, filter: "all" },
+    { range, limit: 5, offset: 0, filter: "all" },
     { enabled: !hasSearch },
   );
 
   const { data: topClients } = api.stats.topClients.useQuery(
-    { range, limit: 5, filter: "all" },
+    { range, limit: 5, offset: 0, filter: "all" },
     { enabled: !hasSearch },
   );
 

--- a/src/hooks/use-prefetch-adjacent-pages.ts
+++ b/src/hooks/use-prefetch-adjacent-pages.ts
@@ -1,0 +1,49 @@
+import { useEffect } from "react";
+
+interface UsePrefetchAdjacentPagesOptions {
+  enabled: boolean;
+  currentPage: number;
+  totalPages: number;
+  prefetchPage: (page: number) => void;
+}
+
+export function usePrefetchAdjacentPages({
+  enabled,
+  currentPage,
+  totalPages,
+  prefetchPage,
+}: UsePrefetchAdjacentPagesOptions) {
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    const pages: number[] = [];
+
+    if (currentPage > 0) {
+      pages.push(currentPage - 1);
+    }
+
+    if (currentPage < totalPages - 1) {
+      pages.push(currentPage + 1);
+    }
+
+    if (pages.length === 0) {
+      return;
+    }
+
+    const run = () => {
+      for (const page of pages) {
+        prefetchPage(page);
+      }
+    };
+
+    if (window.requestIdleCallback) {
+      const idleId = window.requestIdleCallback(run);
+      return () => window.cancelIdleCallback(idleId);
+    }
+
+    const timeoutId = window.setTimeout(run, 0);
+    return () => window.clearTimeout(timeoutId);
+  }, [currentPage, enabled, prefetchPage, totalPages]);
+}

--- a/src/server/logs/__tests__/provider-conformance.test.ts
+++ b/src/server/logs/__tests__/provider-conformance.test.ts
@@ -382,6 +382,22 @@ function defineProviderTests(providerName: string) {
         expect(result.totalCount).toBe(uniqueDomains.size);
       });
 
+      it("out-of-range pagination returns empty items with totalCount", async () => {
+        const inRange = entriesInRange("30d");
+        const uniqueDomains = new Set(
+          inRange.map((e) => e.questionName ?? "unknown"),
+        );
+        const result = await provider.getTopDomains({
+          range: "30d",
+          limit: 10,
+          offset: uniqueDomains.size + 10,
+          filter: "all",
+        });
+
+        expect(result.items).toEqual([]);
+        expect(result.totalCount).toBe(uniqueDomains.size);
+      });
+
       it("percentage is correct", async () => {
         const inRange = entriesInRange("30d");
         const totalEntries = inRange.length;
@@ -508,6 +524,22 @@ function defineProviderTests(providerName: string) {
           offset: 0,
           filter: "all",
         });
+        expect(result.totalCount).toBe(uniqueClients.size);
+      });
+
+      it("out-of-range pagination returns empty items with totalCount", async () => {
+        const inRange = entriesInRange("30d");
+        const uniqueClients = new Set(
+          inRange.map((e) => e.clientName ?? "unknown"),
+        );
+        const result = await provider.getTopClients({
+          range: "30d",
+          limit: 10,
+          offset: uniqueClients.size + 10,
+          filter: "all",
+        });
+
+        expect(result.items).toEqual([]);
         expect(result.totalCount).toBe(uniqueClients.size);
       });
 

--- a/src/server/logs/mysql/provider.ts
+++ b/src/server/logs/mysql/provider.ts
@@ -43,6 +43,18 @@ export class MySQLLogProvider extends BaseSqlLogProvider {
     await this.pool.end();
   }
 
+  protected formatDateTimeForFilter(date: Date): string {
+    const year = date.getUTCFullYear();
+    const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+    const day = String(date.getUTCDate()).padStart(2, "0");
+    const hours = String(date.getUTCHours()).padStart(2, "0");
+    const minutes = String(date.getUTCMinutes()).padStart(2, "0");
+    const seconds = String(date.getUTCSeconds()).padStart(2, "0");
+    const milliseconds = String(date.getUTCMilliseconds()).padStart(3, "0");
+
+    return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}.${milliseconds}`;
+  }
+
   protected getBucketExpression(range: TimeRange): SQL {
     const col = logEntries.requestTs.name;
 

--- a/src/server/logs/sql/base-provider.ts
+++ b/src/server/logs/sql/base-provider.ts
@@ -60,6 +60,22 @@ type AnyTable = any;
 
 type SqlFilter = ReturnType<typeof eq>;
 
+interface TopDomainsRow {
+  domain: string | null;
+  count: number;
+  blocked: number;
+  totalCount: number;
+  totalQueriesCount: number;
+}
+
+interface TopClientsRow {
+  client: string | null;
+  total: number;
+  blocked: number;
+  totalCount: number;
+  totalQueriesCount: number;
+}
+
 export interface BaseSqlLogProviderConfig {
   db: AnyDrizzleDb;
   table: AnyTable;
@@ -87,30 +103,42 @@ export abstract class BaseSqlLogProvider implements LogProvider {
    */
   protected abstract getBucketExpression(range: TimeRange): SQL;
 
-  private buildFiltersAndGetTotalCount(options: {
+  protected formatDateTimeForFilter(date: Date): string {
+    return date.toISOString();
+  }
+
+  private buildRangeFilters(options: {
     range: TimeRange;
     filter: "all" | "blocked";
-  }): {
-    filters: SqlFilter[];
-    getTotalCount: () => Promise<number>;
-  } {
+  }): SqlFilter[] {
     const { startTime } = getTimeRangeConfig(options.range);
     const filters: SqlFilter[] = [
-      gte(this.columns.requestTs, startTime.toISOString()),
+      gte(this.columns.requestTs, this.formatDateTimeForFilter(startTime)),
     ];
+
     if (options.filter === "blocked") {
       filters.push(eq(this.columns.responseType, "BLOCKED"));
     }
 
-    const getTotalCount = async () => {
-      const result = await this.db
-        .select({ count: sql<number>`count(*)` })
-        .from(this.table)
-        .where(and(...filters));
-      return Number(result[0]?.count ?? 0);
-    };
+    return filters;
+  }
 
-    return { filters, getTotalCount };
+  private async getGroupedTotals(options: {
+    filters: SqlFilter[];
+    groupColumn: Column;
+  }): Promise<{ totalCount: number; totalQueriesCount: number }> {
+    const result = await this.db
+      .select({
+        totalCount: sql<number>`count(distinct coalesce(${options.groupColumn}, '__null__'))`,
+        totalQueriesCount: sql<number>`count(*)`,
+      })
+      .from(this.table)
+      .where(and(...options.filters));
+
+    return {
+      totalCount: Number(result[0]?.totalCount ?? 0),
+      totalQueriesCount: Number(result[0]?.totalQueriesCount ?? 0),
+    };
   }
 
   /**
@@ -172,9 +200,6 @@ export abstract class BaseSqlLogProvider implements LogProvider {
       .from(this.table)
       .where(filters.length > 0 ? and(...filters) : undefined);
 
-    const countResult = await countQuery;
-    const count = countResult?.[0]?.count ?? 0;
-
     const selectFields: Record<string, Column | SQL> = {
       requestTs: this.columns.requestTs,
       clientIp: this.columns.clientIp,
@@ -203,7 +228,8 @@ export abstract class BaseSqlLogProvider implements LogProvider {
       .offset(options.offset)
       .where(filters.length > 0 ? and(...filters) : undefined);
 
-    const rows = await query;
+    const [countResult, rows] = await Promise.all([countQuery, query]);
+    const count = countResult?.[0]?.count ?? 0;
 
     return {
       items: rows.map((row: Record<string, unknown>) =>
@@ -222,7 +248,9 @@ export abstract class BaseSqlLogProvider implements LogProvider {
         blocked: sql<number>`sum(case when ${this.columns.responseType} = 'BLOCKED' then 1 else 0 end)`,
       })
       .from(this.table)
-      .where(gte(this.columns.requestTs, oneDayAgo.toISOString()));
+      .where(
+        gte(this.columns.requestTs, this.formatDateTimeForFilter(oneDayAgo)),
+      );
 
     return {
       totalQueries: Number(result[0]?.totalQueries ?? 0),
@@ -238,7 +266,9 @@ export abstract class BaseSqlLogProvider implements LogProvider {
     const { startTime, interval } = getTimeRangeConfig(options.range);
     const bucketExpr = this.getBucketExpression(options.range);
 
-    const filters = [gte(this.columns.requestTs, startTime.toISOString())];
+    const filters = [
+      gte(this.columns.requestTs, this.formatDateTimeForFilter(startTime)),
+    ];
 
     if (options.domain) {
       filters.push(
@@ -273,23 +303,15 @@ export abstract class BaseSqlLogProvider implements LogProvider {
     offset: number;
     filter: "all" | "blocked";
   }): Promise<{ items: TopDomainEntry[]; totalCount: number }> {
-    const { filters, getTotalCount } =
-      this.buildFiltersAndGetTotalCount(options);
-    const totalQueriesCount = await getTotalCount();
-
-    const uniqueDomainsResult = await this.db
-      .select({
-        count: sql<number>`count(distinct coalesce(${this.columns.questionName}, '__null__'))`,
-      })
-      .from(this.table)
-      .where(and(...filters));
-    const totalCount = Number(uniqueDomainsResult[0]?.count ?? 0);
+    const filters = this.buildRangeFilters(options);
 
     const result = await this.db
       .select({
         domain: this.columns.questionName,
         count: sql<number>`count(*)`,
         blocked: sql<number>`sum(case when ${this.columns.responseType} = 'BLOCKED' then 1 else 0 end)`,
+        totalCount: sql<number>`count(*) over ()`,
+        totalQueriesCount: sql<number>`sum(count(*)) over ()`,
       })
       .from(this.table)
       .where(and(...filters))
@@ -298,18 +320,28 @@ export abstract class BaseSqlLogProvider implements LogProvider {
       .limit(options.limit)
       .offset(options.offset);
 
+    let totalQueriesCount = Number(result[0]?.totalQueriesCount ?? 0);
+    let totalCount = Number(result[0]?.totalCount ?? 0);
+
+    if (result.length === 0 && options.offset > 0) {
+      const totals = await this.getGroupedTotals({
+        filters,
+        groupColumn: this.columns.questionName,
+      });
+      totalQueriesCount = totals.totalQueriesCount;
+      totalCount = totals.totalCount;
+    }
+
     return {
-      items: result.map(
-        (row: { domain: string | null; count: number; blocked: number }) => ({
-          domain: row.domain ?? "unknown",
-          count: Number(row.count),
-          blocked: Number(row.blocked),
-          percentage:
-            totalQueriesCount > 0
-              ? (Number(row.count) / totalQueriesCount) * 100
-              : 0,
-        }),
-      ),
+      items: result.map((row: TopDomainsRow) => ({
+        domain: row.domain ?? "unknown",
+        count: Number(row.count),
+        blocked: Number(row.blocked),
+        percentage:
+          totalQueriesCount > 0
+            ? (Number(row.count) / totalQueriesCount) * 100
+            : 0,
+      })),
       totalCount,
     };
   }
@@ -320,23 +352,15 @@ export abstract class BaseSqlLogProvider implements LogProvider {
     offset: number;
     filter: "all" | "blocked";
   }): Promise<{ items: TopClientEntry[]; totalCount: number }> {
-    const { filters, getTotalCount } =
-      this.buildFiltersAndGetTotalCount(options);
-    const totalQueriesCount = await getTotalCount();
-
-    const uniqueClientsResult = await this.db
-      .select({
-        count: sql<number>`count(distinct coalesce(${this.columns.clientName}, '__null__'))`,
-      })
-      .from(this.table)
-      .where(and(...filters));
-    const totalCount = Number(uniqueClientsResult[0]?.count ?? 0);
+    const filters = this.buildRangeFilters(options);
 
     const result = await this.db
       .select({
         client: this.columns.clientName,
         total: sql<number>`count(*)`,
         blocked: sql<number>`sum(case when ${this.columns.responseType} = 'BLOCKED' then 1 else 0 end)`,
+        totalCount: sql<number>`count(*) over ()`,
+        totalQueriesCount: sql<number>`sum(count(*)) over ()`,
       })
       .from(this.table)
       .where(and(...filters))
@@ -345,18 +369,28 @@ export abstract class BaseSqlLogProvider implements LogProvider {
       .limit(options.limit)
       .offset(options.offset);
 
+    let totalQueriesCount = Number(result[0]?.totalQueriesCount ?? 0);
+    let totalCount = Number(result[0]?.totalCount ?? 0);
+
+    if (result.length === 0 && options.offset > 0) {
+      const totals = await this.getGroupedTotals({
+        filters,
+        groupColumn: this.columns.clientName,
+      });
+      totalQueriesCount = totals.totalQueriesCount;
+      totalCount = totals.totalCount;
+    }
+
     return {
-      items: result.map(
-        (row: { client: string | null; total: number; blocked: number }) => ({
-          client: row.client ?? "unknown",
-          total: Number(row.total),
-          blocked: Number(row.blocked),
-          percentage:
-            totalQueriesCount > 0
-              ? (Number(row.total) / totalQueriesCount) * 100
-              : 0,
-        }),
-      ),
+      items: result.map((row: TopClientsRow) => ({
+        client: row.client ?? "unknown",
+        total: Number(row.total),
+        blocked: Number(row.blocked),
+        percentage:
+          totalQueriesCount > 0
+            ? (Number(row.total) / totalQueriesCount) * 100
+            : 0,
+      })),
       totalCount,
     };
   }
@@ -367,7 +401,9 @@ export abstract class BaseSqlLogProvider implements LogProvider {
     const totalResult = await this.db
       .select({ count: sql<number>`count(*)` })
       .from(this.table)
-      .where(gte(this.columns.requestTs, startTime.toISOString()));
+      .where(
+        gte(this.columns.requestTs, this.formatDateTimeForFilter(startTime)),
+      );
     const totalCount = Number(totalResult[0]?.count ?? 0);
 
     const result = await this.db
@@ -376,7 +412,9 @@ export abstract class BaseSqlLogProvider implements LogProvider {
         count: sql<number>`count(*)`,
       })
       .from(this.table)
-      .where(gte(this.columns.requestTs, startTime.toISOString()))
+      .where(
+        gte(this.columns.requestTs, this.formatDateTimeForFilter(startTime)),
+      )
       .groupBy(this.columns.questionType)
       .orderBy(desc(sql`count(*)`), asc(this.columns.questionType));
 
@@ -406,7 +444,7 @@ export abstract class BaseSqlLogProvider implements LogProvider {
       .from(this.table)
       .where(
         and(
-          gte(this.columns.requestTs, startTime.toISOString()),
+          gte(this.columns.requestTs, this.formatDateTimeForFilter(startTime)),
           sql`LOWER(${this.columns.questionName}) LIKE LOWER(${`%${options.query}%`})`,
         ),
       )
@@ -439,7 +477,7 @@ export abstract class BaseSqlLogProvider implements LogProvider {
       .from(this.table)
       .where(
         and(
-          gte(this.columns.requestTs, startTime.toISOString()),
+          gte(this.columns.requestTs, this.formatDateTimeForFilter(startTime)),
           sql`LOWER(${this.columns.clientName}) LIKE LOWER(${`%${options.query}%`})`,
         ),
       )


### PR DESCRIPTION
## Summary
- Adds a reusable adjacent-page prefetch hook and uses it in query logs and top clients/domains tables.
- Updates SQL log providers to handle out-of-range pagination cleanly while preserving total counts and percentage calculations.
- Normalizes MySQL datetime filtering and adds conformance coverage for empty-page pagination behavior.