### PR TITLE
Revert "Update Node.js to v24"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG BUILDER_PLATFORM=linux/amd64
 
 # 1) base image for the final container (native, multi-arch)
-FROM node:24-alpine AS base
+FROM node:22-alpine AS base
 WORKDIR /app
 
 # 2) builder base (FORCED to amd64 due to nextjs build issues on armv6/v7)


### PR DESCRIPTION
Reverts GabeDuarteM/blocky-ui#286

node v24 drops support for armv6 and armv7