### PR TITLE
fix arm sqlite docker builds

### DIFF
--- a/.changeset/forty-donuts-grab.md
+++ b/.changeset/forty-donuts-grab.md
@@ -1,0 +1,7 @@
+---
+"blocky-ui": patch
+---
+
+Fix SQLite query log support in armv6 and armv7 Docker images.
+
+The Docker build now compiles the `better-sqlite3` native addon for each target runtime platform before copying it into the final image, so SQLite query logs work on 32-bit ARM images.

--- a/.github/actions/publish-docker-image/action.yml
+++ b/.github/actions/publish-docker-image/action.yml
@@ -15,9 +15,16 @@ inputs:
   ghcr-token:
     description: GitHub token with package write permission.
     required: true
+  cache-ref:
+    description: BuildKit registry cache reference.
+    required: true
   labels:
     description: Docker image labels.
     required: false
+  platforms:
+    description: Target platforms to build.
+    required: false
+    default: linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7
   tags:
     description: Docker image tags.
     required: true
@@ -50,8 +57,10 @@ runs:
       with:
         context: ${{ inputs.context }}
         push: true
-        platforms: linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7
+        platforms: ${{ inputs.platforms }}
         build-args: |
           BUILDER_PLATFORM=linux/amd64
+        cache-from: type=registry,ref=${{ inputs.cache-ref }}
+        cache-to: type=registry,ref=${{ inputs.cache-ref }},mode=max
         tags: ${{ inputs.tags }}
         labels: ${{ inputs.labels }}

--- a/.github/workflows/pr-image.yml
+++ b/.github/workflows/pr-image.yml
@@ -12,6 +12,10 @@ on:
       pr_number:
         description: Pull request number to build and create the image from.
         required: true
+      platforms:
+        description: Platforms to build.
+        required: false
+        default: linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7
 
 permissions:
   contents: read
@@ -58,6 +62,8 @@ jobs:
         uses: ./.github/actions/publish-docker-image
         with:
           ghcr-token: ${{ secrets.GITHUB_TOKEN }}
+          cache-ref: ${{ env.GHCR_IMAGE }}:buildcache
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
@@ -130,7 +136,9 @@ jobs:
         uses: ./.github/actions/publish-docker-image
         with:
           ghcr-token: ${{ secrets.GITHUB_TOKEN }}
+          cache-ref: ${{ env.GHCR_IMAGE }}:buildcache
           context: pr
+          platforms: ${{ inputs.platforms }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,7 @@ jobs:
         uses: ./.github/actions/publish-docker-image
         with:
           ghcr-token: ${{ secrets.GITHUB_TOKEN }}
+          cache-ref: ${{ env.GHCR_IMAGE }}:buildcache
           dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
           dockerhub-password: ${{ secrets.DOCKERHUB_TOKEN }}
           tags: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,14 @@ FROM deps AS builder
 COPY . .
 RUN bun run build
 
+# Build better-sqlite3 on the target platform; the Next.js build runs on amd64 and would otherwise trace the wrong native addon.
+FROM node:22-alpine AS native-sqlite
+WORKDIR /app
+RUN apk add --no-cache g++ make python3
+COPY package.json ./
+RUN sqlite_version="$(node -p 'require("./package.json").dependencies["better-sqlite3"]')" \
+  && npm_config_build_from_source=true npm install --omit=dev --package-lock=false "better-sqlite3@${sqlite_version}"
+
 FROM node:22-alpine AS runner
 WORKDIR /app
 ENV NODE_ENV=production
@@ -25,6 +33,9 @@ RUN addgroup --system --gid 1001 nodejs \
 COPY --from=builder /app/public ./public
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+COPY --from=native-sqlite --chown=nextjs:nodejs \
+  /app/node_modules/better-sqlite3/build/Release/better_sqlite3.node \
+  ./node_modules/better-sqlite3/build/Release/better_sqlite3.node
 
 USER nextjs
 


### PR DESCRIPTION
Fix SQLite query log support in armv6 and armv7 Docker images.

The Docker build now compiles the `better-sqlite3` native addon for each target runtime platform before copying it into the final image, so SQLite query logs work on 32-bit ARM images.