### PR TITLE
fix: clarify blocking status card

### DIFF
--- a/.changeset/sunny-regions-repeat.md
+++ b/.changeset/sunny-regions-repeat.md
@@ -1,0 +1,5 @@
+---
+"blocky-ui": patch
+---
+
+Clarify the Blocking Status card to show that its controls enable or disable query blocking without stopping the DNS server. Fixes #353

--- a/src/components/dashboard/server-status.tsx
+++ b/src/components/dashboard/server-status.tsx
@@ -97,11 +97,11 @@ export function ServerStatus() {
   if (error) {
     description = "";
   } else if (status?.enabled) {
-    description = "DNS server is currently running and processing queries.";
+    description = "Blocking is currently enabled.";
   } else if (countdown) {
-    description = `DNS server is temporarily disabled. Auto-enables in ${formatTime(countdown)}.`;
+    description = `Blocking is temporarily disabled. Auto-enables in ${formatTime(countdown)}.`;
   } else if (!isLoading) {
-    description = "DNS server is permanently disabled until manually enabled.";
+    description = "Blocking is disabled until manually enabled.";
   }
 
   let content = null;
@@ -164,7 +164,7 @@ export function ServerStatus() {
         <CardTitle className="flex items-center justify-between">
           <span className="flex items-center gap-2">
             <Database className="h-5 w-5" />
-            Server Status
+            Blocking Status
           </span>
           <Badge
             variant="outline"


### PR DESCRIPTION
Wording on the old "DNS server" card could be misleading, changing it to "Blocking" to make it closer to what it actually represents

Closes #353
