### PR TITLE
Enforce code quality checks in verify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ next-env.d.ts
 # misc
 .DS_Store
 *.pem
+/.worktrees/
 
 # debug
 npm-debug.log*

--- a/bun.lock
+++ b/bun.lock
@@ -62,6 +62,7 @@
         "prettier": "3.9.5",
         "prettier-plugin-tailwindcss": "0.8.0",
         "tailwindcss": "4.3.2",
+        "testcontainers": "12.0.4",
         "tw-animate-css": "1.4.0",
         "typescript": "6.0.3",
         "vitest": "4.1.10",

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -1,6 +1,7 @@
 {
-  "$schema": "https://unpkg.com/knip@5/schema.json",
-  "entry": ["scripts/generate_querylog_csv.ts", "src/trpc/server.ts"],
+  "$schema": "./node_modules/knip/schema.json",
+  "entry": ["drizzle.config.*.ts", "src/trpc/server.ts"],
+  "ignoreBinaries": ["podman"],
   "ignoreExportsUsedInFile": {
     "interface": true,
     "type": true

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "start": "next start",
     "typecheck": "tsc --noEmit",
     "changeset": "bunx @changesets/cli",
-    "verify": "bun run --parallel lint format:check typecheck",
+    "verify": "bun run --parallel lint format:check typecheck knip checkdupe",
     "generate:csv": "bunx tsx scripts/generate_querylog_csv.ts --output ./generated-logs --rows 10000 --days 1",
     "generate:csv-client": "bunx tsx scripts/generate_querylog_csv.ts --output ./generated-logs --rows 10000 --days 1 --type csv-client --clients 5",
     "knip": "SKIP_ENV_VALIDATION=true knip",
@@ -84,6 +84,7 @@
     "prettier": "3.9.5",
     "prettier-plugin-tailwindcss": "0.8.0",
     "tailwindcss": "4.3.2",
+    "testcontainers": "12.0.4",
     "tw-animate-css": "1.4.0",
     "typescript": "6.0.3",
     "vitest": "4.1.10"

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -4,7 +4,8 @@ import { cva, type VariantProps } from "class-variance-authority"
 
 import { cn } from "~/lib/utils"
 
-const buttonVariants = cva(
+/** @knipignore */
+export const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
     variants: {
@@ -56,4 +57,4 @@ function Button({
   )
 }
 
-export { Button, /** @knipignore */ buttonVariants }
+export { Button }

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -48,7 +48,11 @@ function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
-function CardAction({ className, ...props }: React.ComponentProps<"div">) {
+/** @knipignore */
+export function CardAction({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-action"
@@ -86,7 +90,6 @@ export {
   CardHeader,
   CardFooter,
   CardTitle,
-  /** @knipignore */ CardAction,
   CardDescription,
   CardContent,
 }

--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -69,7 +69,8 @@ function ChartContainer({
   )
 }
 
-const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
+/** @knipignore */
+export const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
   const colorConfig = Object.entries(config).filter(
     ([, config]) => config.theme || config.color
   )
@@ -264,7 +265,8 @@ function ChartTooltipContent({
 
 const ChartLegend = RechartsPrimitive.Legend
 
-function ChartLegendContent({
+/** @knipignore */
+export function ChartLegendContent({
   className,
   hideIcon = false,
   payload,
@@ -364,6 +366,4 @@ export {
   ChartTooltip,
   ChartTooltipContent,
   ChartLegend,
-  /** @knipignore */ ChartLegendContent,
-  /** @knipignore */ ChartStyle,
 }

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -29,7 +29,8 @@ function Command({
   )
 }
 
-function CommandDialog({
+/** @knipignore */
+export function CommandDialog({
   title = "Command Palette",
   description = "Search for a command to run...",
   children,
@@ -126,7 +127,8 @@ function CommandGroup({
   )
 }
 
-function CommandSeparator({
+/** @knipignore */
+export function CommandSeparator({
   className,
   ...props
 }: React.ComponentProps<typeof CommandPrimitive.Separator>) {
@@ -155,7 +157,8 @@ function CommandItem({
   )
 }
 
-function CommandShortcut({
+/** @knipignore */
+export function CommandShortcut({
   className,
   ...props
 }: React.ComponentProps<"span">) {
@@ -173,12 +176,9 @@ function CommandShortcut({
 
 export {
   Command,
-  /** @knipignore */ CommandDialog,
   CommandInput,
   CommandList,
   CommandEmpty,
   CommandGroup,
   CommandItem,
-  /** @knipignore */ CommandShortcut,
-  /** @knipignore */ CommandSeparator,
 }

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -12,25 +12,29 @@ function Dialog({
   return <DialogPrimitive.Root data-slot="dialog" {...props} />
 }
 
-function DialogTrigger({
+/** @knipignore */
+export function DialogTrigger({
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
   return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
 }
 
-function DialogPortal({
+/** @knipignore */
+export function DialogPortal({
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Portal>) {
   return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
 }
 
-function DialogClose({
+/** @knipignore */
+export function DialogClose({
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Close>) {
   return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
 }
 
-function DialogOverlay({
+/** @knipignore */
+export function DialogOverlay({
   className,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
@@ -90,7 +94,11 @@ function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
-function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
+/** @knipignore */
+export function DialogFooter({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="dialog-footer"
@@ -131,13 +139,8 @@ function DialogDescription({
 
 export {
   Dialog,
-  /** @knipignore */ DialogClose,
   DialogContent,
   DialogDescription,
-  /** @knipignore */ DialogFooter,
   DialogHeader,
-  /** @knipignore */ DialogOverlay,
-  /** @knipignore */ DialogPortal,
   DialogTitle,
-  /** @knipignore */ DialogTrigger,
 }

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -12,7 +12,8 @@ function Select({
   return <SelectPrimitive.Root data-slot="select" {...props} />
 }
 
-function SelectGroup({
+/** @knipignore */
+export function SelectGroup({
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Group>) {
   return <SelectPrimitive.Group data-slot="select-group" {...props} />
@@ -85,7 +86,8 @@ function SelectContent({
   )
 }
 
-function SelectLabel({
+/** @knipignore */
+export function SelectLabel({
   className,
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Label>) {
@@ -122,7 +124,8 @@ function SelectItem({
   )
 }
 
-function SelectSeparator({
+/** @knipignore */
+export function SelectSeparator({
   className,
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Separator>) {
@@ -135,7 +138,8 @@ function SelectSeparator({
   )
 }
 
-function SelectScrollUpButton({
+/** @knipignore */
+export function SelectScrollUpButton({
   className,
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
@@ -153,7 +157,8 @@ function SelectScrollUpButton({
   )
 }
 
-function SelectScrollDownButton({
+/** @knipignore */
+export function SelectScrollDownButton({
   className,
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
@@ -174,12 +179,7 @@ function SelectScrollDownButton({
 export {
   Select,
   SelectContent,
-  /** @knipignore */ SelectGroup,
   SelectItem,
-  /** @knipignore */ SelectLabel,
-  /** @knipignore */ SelectScrollDownButton,
-  /** @knipignore */ SelectScrollUpButton,
-  /** @knipignore */ SelectSeparator,
   SelectTrigger,
   SelectValue,
 }

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -39,7 +39,11 @@ function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
   )
 }
 
-function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
+/** @knipignore */
+export function TableFooter({
+  className,
+  ...props
+}: React.ComponentProps<"tfoot">) {
   return (
     <tfoot
       data-slot="table-footer"
@@ -91,7 +95,8 @@ function TableCell({ className, ...props }: React.ComponentProps<"td">) {
   )
 }
 
-function TableCaption({
+/** @knipignore */
+export function TableCaption({
   className,
   ...props
 }: React.ComponentProps<"caption">) {
@@ -108,9 +113,7 @@ export {
   Table,
   TableHeader,
   TableBody,
-  /** @knipignore */ TableFooter,
   TableHead,
   TableRow,
   TableCell,
-  /** @knipignore */ TableCaption,
 }

--- a/src/server/logs/__tests__/setup.ts
+++ b/src/server/logs/__tests__/setup.ts
@@ -113,6 +113,26 @@ function isoToSqliteDatetime(iso: string): string {
   return isoToMysqlDatetime(iso);
 }
 
+function entryToDatabaseValues(
+  entry: LogEntry,
+  formatRequestTs: (requestTs: string) => string = (requestTs) => requestTs,
+) {
+  return {
+    requestTs: entry.requestTs ? formatRequestTs(entry.requestTs) : null,
+    clientIp: entry.clientIp,
+    clientName: entry.clientName,
+    durationMs: entry.durationMs,
+    reason: entry.reason,
+    responseType: entry.responseType,
+    questionType: entry.questionType,
+    questionName: entry.questionName,
+    effectiveTldp: entry.effectiveTldp,
+    answer: entry.answer,
+    responseCode: entry.responseCode,
+    hostname: entry.hostname,
+  };
+}
+
 // Field order must match INSERT_SQL column order exactly
 function entryToMysqlRow(entry: LogEntry): unknown[] {
   return [
@@ -194,22 +214,9 @@ async function setupPostgres(entries: LogEntry[]): Promise<{
       `);
 
       if (entries.length > 0) {
-        await db.insert(pgLogEntries).values(
-          entries.map((entry) => ({
-            requestTs: entry.requestTs,
-            clientIp: entry.clientIp,
-            clientName: entry.clientName,
-            durationMs: entry.durationMs,
-            reason: entry.reason,
-            responseType: entry.responseType,
-            questionType: entry.questionType,
-            questionName: entry.questionName,
-            effectiveTldp: entry.effectiveTldp,
-            answer: entry.answer,
-            responseCode: entry.responseCode,
-            hostname: entry.hostname,
-          })),
-        );
+        await db
+          .insert(pgLogEntries)
+          .values(entries.map((entry) => entryToDatabaseValues(entry)));
       }
     } finally {
       await conn.end();
@@ -262,22 +269,9 @@ function setupSqlite(entries: LogEntry[]): {
     if (entries.length > 0) {
       db.insert(sqliteLogEntries)
         .values(
-          entries.map((entry) => ({
-            requestTs: entry.requestTs
-              ? isoToSqliteDatetime(entry.requestTs)
-              : null,
-            clientIp: entry.clientIp,
-            clientName: entry.clientName,
-            durationMs: entry.durationMs,
-            reason: entry.reason,
-            responseType: entry.responseType,
-            questionType: entry.questionType,
-            questionName: entry.questionName,
-            effectiveTldp: entry.effectiveTldp,
-            answer: entry.answer,
-            responseCode: entry.responseCode,
-            hostname: entry.hostname,
-          })),
+          entries.map((entry) =>
+            entryToDatabaseValues(entry, isoToSqliteDatetime),
+          ),
         )
         .run();
     }

--- a/src/server/logs/mysql/provider.ts
+++ b/src/server/logs/mysql/provider.ts
@@ -19,21 +19,7 @@ export class MySQLLogProvider extends BaseSqlLogProvider {
     super({
       db,
       table: logEntries,
-      columns: {
-        id: logEntries.id,
-        requestTs: logEntries.requestTs,
-        clientIp: logEntries.clientIp,
-        clientName: logEntries.clientName,
-        durationMs: logEntries.durationMs,
-        reason: logEntries.reason,
-        responseType: logEntries.responseType,
-        questionType: logEntries.questionType,
-        questionName: logEntries.questionName,
-        effectiveTldp: logEntries.effectiveTldp,
-        answer: logEntries.answer,
-        responseCode: logEntries.responseCode,
-        hostname: logEntries.hostname,
-      },
+      columns: logEntries,
     });
 
     this.pool = pool;
@@ -41,18 +27,6 @@ export class MySQLLogProvider extends BaseSqlLogProvider {
 
   async close(): Promise<void> {
     await this.pool.end();
-  }
-
-  protected formatDateTimeForFilter(date: Date): string {
-    const year = date.getUTCFullYear();
-    const month = String(date.getUTCMonth() + 1).padStart(2, "0");
-    const day = String(date.getUTCDate()).padStart(2, "0");
-    const hours = String(date.getUTCHours()).padStart(2, "0");
-    const minutes = String(date.getUTCMinutes()).padStart(2, "0");
-    const seconds = String(date.getUTCSeconds()).padStart(2, "0");
-    const milliseconds = String(date.getUTCMilliseconds()).padStart(3, "0");
-
-    return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}.${milliseconds}`;
   }
 
   protected getBucketExpression(range: TimeRange): SQL {

--- a/src/server/logs/postgres/provider.ts
+++ b/src/server/logs/postgres/provider.ts
@@ -20,20 +20,7 @@ export class PostgreSQLLogProvider extends BaseSqlLogProvider {
     super({
       db,
       table: logEntries,
-      columns: {
-        requestTs: logEntries.requestTs,
-        clientIp: logEntries.clientIp,
-        clientName: logEntries.clientName,
-        durationMs: logEntries.durationMs,
-        reason: logEntries.reason,
-        responseType: logEntries.responseType,
-        questionType: logEntries.questionType,
-        questionName: logEntries.questionName,
-        effectiveTldp: logEntries.effectiveTldp,
-        answer: logEntries.answer,
-        responseCode: logEntries.responseCode,
-        hostname: logEntries.hostname,
-      },
+      columns: logEntries,
     });
 
     this.conn = conn;
@@ -41,6 +28,10 @@ export class PostgreSQLLogProvider extends BaseSqlLogProvider {
 
   async close(): Promise<void> {
     await this.conn.end();
+  }
+
+  protected formatDateTimeForFilter(date: Date): string {
+    return date.toISOString();
   }
 
   protected getBucketExpression(range: TimeRange): SQL {

--- a/src/server/logs/postgres/schema.ts
+++ b/src/server/logs/postgres/schema.ts
@@ -1,21 +1,15 @@
 import { pgTable, index, timestamp, text, bigint } from "drizzle-orm/pg-core";
 
+import { createLogEntryColumns } from "~/server/logs/sql/schema";
+
 export const logEntries = pgTable(
   "log_entries",
-  {
-    requestTs: timestamp("request_ts", { mode: "string", withTimezone: true }),
-    clientIp: text("client_ip"),
-    clientName: text("client_name"),
-    durationMs: bigint("duration_ms", { mode: "number" }),
-    reason: text(),
-    responseType: text("response_type"),
-    questionType: text("question_type"),
-    questionName: text("question_name"),
-    effectiveTldp: text("effective_tldp"),
-    answer: text(),
-    responseCode: text("response_code"),
-    hostname: text(),
-  },
+  createLogEntryColumns({
+    requestTs: (name) =>
+      timestamp(name, { mode: "string", withTimezone: true }),
+    text: (name) => text(name),
+    durationMs: (name) => bigint(name, { mode: "number" }),
+  }),
   (table) => [
     index("idx_log_entries_request_ts").on(table.requestTs),
     index("idx_log_entries_client_name").on(table.clientName),

--- a/src/server/logs/sql/base-provider.ts
+++ b/src/server/logs/sql/base-provider.ts
@@ -76,10 +76,24 @@ interface TopClientsRow {
   totalQueriesCount: number;
 }
 
+interface GroupedTotalsRow {
+  totalCount: number;
+  totalQueriesCount: number;
+}
+
 export interface BaseSqlLogProviderConfig {
   db: AnyDrizzleDb;
   table: AnyTable;
   columns: LogEntriesColumns;
+}
+
+function getUtcDateParts(date: Date) {
+  return {
+    year: date.getUTCFullYear(),
+    month: String(date.getUTCMonth() + 1).padStart(2, "0"),
+    day: String(date.getUTCDate()).padStart(2, "0"),
+    hours: String(date.getUTCHours()).padStart(2, "0"),
+  };
 }
 
 /**
@@ -104,7 +118,12 @@ export abstract class BaseSqlLogProvider implements LogProvider {
   protected abstract getBucketExpression(range: TimeRange): SQL;
 
   protected formatDateTimeForFilter(date: Date): string {
-    return date.toISOString();
+    const { year, month, day, hours } = getUtcDateParts(date);
+    const minutes = String(date.getUTCMinutes()).padStart(2, "0");
+    const seconds = String(date.getUTCSeconds()).padStart(2, "0");
+    const milliseconds = String(date.getUTCMilliseconds()).padStart(3, "0");
+
+    return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}.${milliseconds}`;
   }
 
   protected getTextSortExpression(column: Column): Column | SQL {
@@ -142,6 +161,25 @@ export abstract class BaseSqlLogProvider implements LogProvider {
     return {
       totalCount: Number(result[0]?.totalCount ?? 0),
       totalQueriesCount: Number(result[0]?.totalQueriesCount ?? 0),
+    };
+  }
+
+  private async resolveGroupedTotals(options: {
+    row: GroupedTotalsRow | undefined;
+    offset: number;
+    filters: SqlFilter[];
+    groupColumn: Column;
+  }): Promise<GroupedTotalsRow> {
+    if (!options.row && options.offset > 0) {
+      return this.getGroupedTotals({
+        filters: options.filters,
+        groupColumn: options.groupColumn,
+      });
+    }
+
+    return {
+      totalQueriesCount: Number(options.row?.totalQueriesCount ?? 0),
+      totalCount: Number(options.row?.totalCount ?? 0),
     };
   }
 
@@ -328,17 +366,12 @@ export abstract class BaseSqlLogProvider implements LogProvider {
       .limit(options.limit)
       .offset(options.offset);
 
-    let totalQueriesCount = Number(result[0]?.totalQueriesCount ?? 0);
-    let totalCount = Number(result[0]?.totalCount ?? 0);
-
-    if (result.length === 0 && options.offset > 0) {
-      const totals = await this.getGroupedTotals({
-        filters,
-        groupColumn: this.columns.questionName,
-      });
-      totalQueriesCount = totals.totalQueriesCount;
-      totalCount = totals.totalCount;
-    }
+    const { totalQueriesCount, totalCount } = await this.resolveGroupedTotals({
+      row: result[0],
+      offset: options.offset,
+      filters,
+      groupColumn: this.columns.questionName,
+    });
 
     return {
       items: result.map((row: TopDomainsRow) => ({
@@ -381,17 +414,12 @@ export abstract class BaseSqlLogProvider implements LogProvider {
       .limit(options.limit)
       .offset(options.offset);
 
-    let totalQueriesCount = Number(result[0]?.totalQueriesCount ?? 0);
-    let totalCount = Number(result[0]?.totalCount ?? 0);
-
-    if (result.length === 0 && options.offset > 0) {
-      const totals = await this.getGroupedTotals({
-        filters,
-        groupColumn: this.columns.clientName,
-      });
-      totalQueriesCount = totals.totalQueriesCount;
-      totalCount = totals.totalCount;
-    }
+    const { totalQueriesCount, totalCount } = await this.resolveGroupedTotals({
+      row: result[0],
+      offset: options.offset,
+      filters,
+      groupColumn: this.columns.clientName,
+    });
 
     return {
       items: result.map((row: TopClientsRow) => ({
@@ -519,7 +547,7 @@ export abstract class BaseSqlLogProvider implements LogProvider {
 /**
  * Fills in missing time buckets with zero values.
  */
-export function fillTimeBuckets(
+function fillTimeBuckets(
   data: {
     timeBucket: string;
     total: number;
@@ -556,11 +584,8 @@ export function fillTimeBuckets(
 /**
  * Formats a date to match the SQL bucket expression output.
  */
-export function formatDateForRange(date: Date, range: TimeRange): string {
-  const year = date.getUTCFullYear();
-  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
-  const day = String(date.getUTCDate()).padStart(2, "0");
-  const hours = String(date.getUTCHours()).padStart(2, "0");
+function formatDateForRange(date: Date, range: TimeRange): string {
+  const { year, month, day, hours } = getUtcDateParts(date);
 
   switch (range) {
     case "1h": {

--- a/src/server/logs/sql/schema.ts
+++ b/src/server/logs/sql/schema.ts
@@ -1,0 +1,22 @@
+type ColumnFactory<TColumn> = (name: string) => TColumn;
+
+export function createLogEntryColumns<TRequestTs, TText, TDurationMs>(options: {
+  requestTs: ColumnFactory<TRequestTs>;
+  text: ColumnFactory<TText>;
+  durationMs: ColumnFactory<TDurationMs>;
+}) {
+  return {
+    requestTs: options.requestTs("request_ts"),
+    clientIp: options.text("client_ip"),
+    clientName: options.text("client_name"),
+    durationMs: options.durationMs("duration_ms"),
+    reason: options.text("reason"),
+    responseType: options.text("response_type"),
+    questionType: options.text("question_type"),
+    questionName: options.text("question_name"),
+    effectiveTldp: options.text("effective_tldp"),
+    answer: options.text("answer"),
+    responseCode: options.text("response_code"),
+    hostname: options.text("hostname"),
+  };
+}

--- a/src/server/logs/sqlite/provider.ts
+++ b/src/server/logs/sqlite/provider.ts
@@ -21,20 +21,7 @@ export class SQLiteLogProvider extends BaseSqlLogProvider {
     super({
       db,
       table: logEntries,
-      columns: {
-        requestTs: logEntries.requestTs,
-        clientIp: logEntries.clientIp,
-        clientName: logEntries.clientName,
-        durationMs: logEntries.durationMs,
-        reason: logEntries.reason,
-        responseType: logEntries.responseType,
-        questionType: logEntries.questionType,
-        questionName: logEntries.questionName,
-        effectiveTldp: logEntries.effectiveTldp,
-        answer: logEntries.answer,
-        responseCode: logEntries.responseCode,
-        hostname: logEntries.hostname,
-      },
+      columns: logEntries,
     });
 
     this.dbFile = dbFile;
@@ -42,18 +29,6 @@ export class SQLiteLogProvider extends BaseSqlLogProvider {
 
   async close(): Promise<void> {
     this.dbFile.close();
-  }
-
-  protected formatDateTimeForFilter(date: Date): string {
-    const year = date.getUTCFullYear();
-    const month = String(date.getUTCMonth() + 1).padStart(2, "0");
-    const day = String(date.getUTCDate()).padStart(2, "0");
-    const hours = String(date.getUTCHours()).padStart(2, "0");
-    const minutes = String(date.getUTCMinutes()).padStart(2, "0");
-    const seconds = String(date.getUTCSeconds()).padStart(2, "0");
-    const milliseconds = String(date.getUTCMilliseconds()).padStart(3, "0");
-
-    return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}.${milliseconds}`;
   }
 
   protected getTextSortExpression(column: Column): SQL {

--- a/src/server/logs/sqlite/schema.ts
+++ b/src/server/logs/sqlite/schema.ts
@@ -1,21 +1,14 @@
 import { index, integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
 
+import { createLogEntryColumns } from "~/server/logs/sql/schema";
+
 export const logEntries = sqliteTable(
   "log_entries",
-  {
-    requestTs: text("request_ts"),
-    clientIp: text("client_ip"),
-    clientName: text("client_name"),
-    durationMs: integer("duration_ms"),
-    reason: text(),
-    responseType: text("response_type"),
-    questionType: text("question_type"),
-    questionName: text("question_name"),
-    effectiveTldp: text("effective_tldp"),
-    answer: text(),
-    responseCode: text("response_code"),
-    hostname: text(),
-  },
+  createLogEntryColumns({
+    requestTs: (name) => text(name),
+    text: (name) => text(name),
+    durationMs: (name) => integer(name),
+  }),
   (table) => [
     index("idx_log_entries_request_ts").on(table.requestTs),
     index("idx_log_entries_client_name").on(table.clientName),


### PR DESCRIPTION
## Summary

- Extend `bun run verify` with Knip and duplicate-code checks.
- Refactor shared SQL log schema and provider configuration across MySQL, PostgreSQL, and SQLite.
- Improve grouped totals pagination handling and database-specific timestamp formatting to fix jscpd duplicates.
- Add `testcontainers` and ignore local worktrees to fix some knip issues.