### PR TITLE
Add demo mode configuration devtools bar

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { env } from "~/env";
 
 import "../styles/globals.css";
 import { cn } from "~/lib/utils";
+import { DemoModeProvider } from "~/components/dashboard/demo-mode";
 
 export const metadata = {
   title: env.INSTANCE_NAME ? `BlockyUI @ ${env.INSTANCE_NAME}` : "BlockyUI",
@@ -44,11 +45,13 @@ export default function RootLayout({
       lang="en"
     >
       <body>
-        <TRPCReactProvider>
-          {children}
-          <Toaster />
-          <Pattern />
-        </TRPCReactProvider>
+        {env.DEMO_MODE ? (
+          <DemoModeProvider>{children}</DemoModeProvider>
+        ) : (
+          <TRPCReactProvider>{children}</TRPCReactProvider>
+        )}
+        <Toaster />
+        <Pattern />
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,15 +1,10 @@
-import { ServerStatus } from "~/components/dashboard/server-status";
-import { QueryTool } from "~/components/dashboard/query-tool";
-import { Operations } from "~/components/dashboard/operations";
-import { QueryLogs } from "~/components/dashboard/query-logs/query-logs";
-import { StatisticsOverview } from "~/components/dashboard/statistics/statistics-overview";
-import { ChartsSection } from "~/components/dashboard/statistics/charts-section";
+import { Dashboard } from "~/components/dashboard/dashboard";
 import { env } from "~/env";
 
 export const dynamic = "force-dynamic";
 
 export default function HomePage() {
-  const showLogs = env.QUERY_LOG_TARGET ?? env.DEMO_MODE ?? false;
+  const showLogs = Boolean(env.QUERY_LOG_TARGET ?? env.DEMO_MODE);
 
   return (
     <main className="container mx-auto max-w-5xl px-4 py-8 sm:py-10">
@@ -19,16 +14,7 @@ export default function HomePage() {
         </h1>
       </header>
 
-      <div className="space-y-5 sm:space-y-6">
-        <StatisticsOverview />
-        <div className="grid gap-6 md:grid-cols-2">
-          <ServerStatus />
-          <Operations />
-        </div>
-        {Boolean(showLogs) && <ChartsSection />}
-        <QueryTool />
-        {Boolean(showLogs) && <QueryLogs />}
-      </div>
+      <Dashboard showLogs={showLogs} />
     </main>
   );
 }

--- a/src/components/dashboard/dashboard.tsx
+++ b/src/components/dashboard/dashboard.tsx
@@ -6,11 +6,11 @@ import { QueryTool } from "~/components/dashboard/query-tool";
 import { ServerStatus } from "~/components/dashboard/server-status";
 import { ChartsSection } from "~/components/dashboard/statistics/charts-section";
 import { StatisticsOverview } from "~/components/dashboard/statistics/statistics-overview";
-import { useDemoSetup } from "~/demo/context";
+import { useDemoConfiguration } from "~/demo/context";
 
 export function Dashboard({ showLogs }: { showLogs: boolean }) {
-  const setup = useDemoSetup();
-  const showLogFeatures = showLogs && setup.services.queryLogs;
+  const configuration = useDemoConfiguration();
+  const showLogFeatures = showLogs && configuration.services.queryLogs;
 
   return (
     <div className="space-y-5 sm:space-y-6">

--- a/src/components/dashboard/dashboard.tsx
+++ b/src/components/dashboard/dashboard.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { Operations } from "~/components/dashboard/operations";
+import { QueryLogs } from "~/components/dashboard/query-logs/query-logs";
+import { QueryTool } from "~/components/dashboard/query-tool";
+import { ServerStatus } from "~/components/dashboard/server-status";
+import { ChartsSection } from "~/components/dashboard/statistics/charts-section";
+import { StatisticsOverview } from "~/components/dashboard/statistics/statistics-overview";
+import { useDemoSetup } from "~/demo/context";
+
+export function Dashboard({ showLogs }: { showLogs: boolean }) {
+  const setup = useDemoSetup();
+  const showLogFeatures = showLogs && setup.services.queryLogs;
+
+  return (
+    <div className="space-y-5 sm:space-y-6">
+      <StatisticsOverview />
+      <div className="grid gap-6 md:grid-cols-2">
+        <ServerStatus />
+        <Operations />
+      </div>
+      {showLogFeatures ? <ChartsSection /> : null}
+      <QueryTool />
+      {showLogFeatures ? <QueryLogs /> : null}
+    </div>
+  );
+}

--- a/src/components/dashboard/demo-mode.tsx
+++ b/src/components/dashboard/demo-mode.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { useQueryClient } from "@tanstack/react-query";
+import { ChevronDown, ChevronUp, FlaskConical, Server } from "lucide-react";
+import { type ReactNode, useEffect, useRef, useState } from "react";
+import { Button } from "~/components/ui/button";
+import { DemoSetupProvider, useDemoSetupController } from "~/demo/context";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "~/components/ui/select";
+import { DEMO_SETUPS, getDemoSetup } from "~/demo/config";
+import { TRPCReactProvider } from "~/trpc/react";
+
+export function DemoModeProvider({ children }: { children: ReactNode }) {
+  return (
+    <DemoSetupProvider>
+      <DemoModeContent>{children}</DemoModeContent>
+    </DemoSetupProvider>
+  );
+}
+
+function DemoModeContent({ children }: { children: ReactNode }) {
+  const { setup } = useDemoSetupController();
+
+  return (
+    <TRPCReactProvider demoSetupId={setup.id}>
+      <DemoModeShell>{children}</DemoModeShell>
+    </TRPCReactProvider>
+  );
+}
+
+function DemoModeShell({ children }: { children: ReactNode }) {
+  const [isMinimized, setIsMinimized] = useState(true);
+  const { setup } = useDemoSetupController();
+  const queryClient = useQueryClient();
+  const previousSetupId = useRef(setup.id);
+
+  useEffect(() => {
+    if (previousSetupId.current === setup.id) {
+      return;
+    }
+
+    previousSetupId.current = setup.id;
+    void queryClient.resetQueries();
+  }, [queryClient, setup.id]);
+
+  return (
+    <>
+      <div className={isMinimized ? "pb-28 sm:pb-16" : "pb-60 sm:pb-24"}>
+        {children}
+      </div>
+      <DemoDevtoolsBar
+        isMinimized={isMinimized}
+        onMinimizedChange={setIsMinimized}
+      />
+    </>
+  );
+}
+
+function DemoDevtoolsBar({
+  isMinimized,
+  onMinimizedChange,
+}: {
+  isMinimized: boolean;
+  onMinimizedChange: (isMinimized: boolean) => void;
+}) {
+  const { setup, setSetup } = useDemoSetupController();
+
+  const handleSetupChange = (value: string) => {
+    setSetup(getDemoSetup(value));
+  };
+
+  if (isMinimized) {
+    return (
+      <aside
+        aria-label="Demo configuration"
+        className="pointer-events-none fixed inset-x-3 bottom-16 z-40 flex justify-center sm:bottom-3"
+      >
+        <Button
+          aria-label="Expand demo configuration"
+          variant="outline"
+          onClick={() => onMinimizedChange(false)}
+          className="pointer-events-auto h-10 rounded-full border-amber-400/25 bg-zinc-950/95 px-3 text-zinc-100 shadow-2xl shadow-black/40 backdrop-blur hover:bg-zinc-900 hover:text-zinc-100"
+        >
+          <span className="flex size-6 items-center justify-center rounded-full bg-amber-400 text-zinc-950">
+            <FlaskConical className="size-3.5" />
+          </span>
+          <span className="text-[10px] font-semibold tracking-[0.16em] text-amber-300 uppercase">
+            Demo
+          </span>
+          <span className="h-4 w-px bg-white/10" />
+          <span className="max-w-40 truncate text-xs text-zinc-300">
+            {setup.label}
+          </span>
+          <ChevronUp className="size-3.5 text-zinc-500" />
+        </Button>
+      </aside>
+    );
+  }
+
+  return (
+    <aside
+      aria-label="Demo configuration"
+      className="fixed inset-x-3 bottom-16 z-40 flex flex-col gap-3 rounded-xl border border-amber-400/25 bg-zinc-950/95 p-3 shadow-2xl shadow-black/40 backdrop-blur sm:inset-x-auto sm:bottom-3 sm:left-1/2 sm:w-auto sm:-translate-x-1/2 sm:flex-row sm:items-center sm:gap-3 sm:rounded-full sm:px-3"
+    >
+      <div className="flex shrink-0 items-center gap-2 pr-10 sm:pr-0">
+        <span className="flex size-7 items-center justify-center rounded-full bg-amber-400 text-zinc-950">
+          <FlaskConical className="size-4" />
+        </span>
+        <div className="leading-tight">
+          <p className="text-[10px] font-semibold tracking-[0.18em] text-amber-300 uppercase">
+            Demo mode
+          </p>
+          <p className="hidden text-xs text-zinc-400 sm:block">
+            Preview setup states
+          </p>
+        </div>
+      </div>
+
+      <Select value={setup.id} onValueChange={handleSetupChange}>
+        <SelectTrigger
+          aria-label="Demo setup"
+          size="sm"
+          className="h-9 w-full border-white/10 bg-white/5 text-zinc-100 sm:w-52"
+        >
+          <Server className="size-3.5 text-zinc-400" />
+          <SelectValue>{setup.label}</SelectValue>
+        </SelectTrigger>
+        <SelectContent align="center" className="min-w-72">
+          {DEMO_SETUPS.map((option) => (
+            <SelectItem key={option.id} value={option.id}>
+              <span className="flex flex-col items-start">
+                <span>{option.label}</span>
+                <span className="text-muted-foreground text-xs">
+                  {option.description}
+                </span>
+              </span>
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      <Button
+        aria-label="Minimize demo configuration"
+        size="icon"
+        variant="ghost"
+        onClick={() => onMinimizedChange(true)}
+        className="absolute top-2 right-2 size-8 rounded-full text-zinc-500 hover:bg-white/10 hover:text-zinc-200 sm:static"
+      >
+        <ChevronDown className="size-4" />
+      </Button>
+    </aside>
+  );
+}

--- a/src/components/dashboard/demo-mode.tsx
+++ b/src/components/dashboard/demo-mode.tsx
@@ -4,30 +4,33 @@ import { useQueryClient } from "@tanstack/react-query";
 import { ChevronDown, ChevronUp, FlaskConical, Server } from "lucide-react";
 import { type ReactNode, useEffect, useRef, useState } from "react";
 import { Button } from "~/components/ui/button";
-import { DemoSetupProvider, useDemoSetupController } from "~/demo/context";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "~/components/ui/select";
-import { DEMO_SETUPS, getDemoSetup } from "~/demo/config";
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "~/components/ui/popover";
+import { Switch } from "~/components/ui/switch";
+import { DEMO_SERVICES, serializeDemoConfiguration } from "~/demo/config";
+import {
+  DemoConfigurationProvider,
+  useDemoConfigurationController,
+} from "~/demo/context";
 import { TRPCReactProvider } from "~/trpc/react";
 
 export function DemoModeProvider({ children }: { children: ReactNode }) {
   return (
-    <DemoSetupProvider>
+    <DemoConfigurationProvider>
       <DemoModeContent>{children}</DemoModeContent>
-    </DemoSetupProvider>
+    </DemoConfigurationProvider>
   );
 }
 
 function DemoModeContent({ children }: { children: ReactNode }) {
-  const { setup } = useDemoSetupController();
+  const { configuration } = useDemoConfigurationController();
+  const serializedConfiguration = serializeDemoConfiguration(configuration);
 
   return (
-    <TRPCReactProvider demoSetupId={setup.id}>
+    <TRPCReactProvider demoConfiguration={serializedConfiguration}>
       <DemoModeShell>{children}</DemoModeShell>
     </TRPCReactProvider>
   );
@@ -35,18 +38,19 @@ function DemoModeContent({ children }: { children: ReactNode }) {
 
 function DemoModeShell({ children }: { children: ReactNode }) {
   const [isMinimized, setIsMinimized] = useState(true);
-  const { setup } = useDemoSetupController();
+  const { configuration } = useDemoConfigurationController();
+  const serializedConfiguration = serializeDemoConfiguration(configuration);
   const queryClient = useQueryClient();
-  const previousSetupId = useRef(setup.id);
+  const previousConfiguration = useRef(serializedConfiguration);
 
   useEffect(() => {
-    if (previousSetupId.current === setup.id) {
+    if (previousConfiguration.current === serializedConfiguration) {
       return;
     }
 
-    previousSetupId.current = setup.id;
+    previousConfiguration.current = serializedConfiguration;
     void queryClient.resetQueries();
-  }, [queryClient, setup.id]);
+  }, [queryClient, serializedConfiguration]);
 
   return (
     <>
@@ -68,11 +72,13 @@ function DemoDevtoolsBar({
   isMinimized: boolean;
   onMinimizedChange: (isMinimized: boolean) => void;
 }) {
-  const { setup, setSetup } = useDemoSetupController();
-
-  const handleSetupChange = (value: string) => {
-    setSetup(getDemoSetup(value));
-  };
+  const { configuration, setServiceEnabled } = useDemoConfigurationController();
+  const enabledServices = DEMO_SERVICES.filter(
+    ({ id }) => configuration.services[id],
+  );
+  const selectionLabel = getSelectionLabel(
+    enabledServices.map((service) => service.label),
+  );
 
   if (isMinimized) {
     return (
@@ -94,7 +100,7 @@ function DemoDevtoolsBar({
           </span>
           <span className="h-4 w-px bg-white/10" />
           <span className="max-w-40 truncate text-xs text-zinc-300">
-            {setup.label}
+            {selectionLabel}
           </span>
           <ChevronUp className="size-3.5 text-zinc-500" />
         </Button>
@@ -116,33 +122,57 @@ function DemoDevtoolsBar({
             Demo mode
           </p>
           <p className="hidden text-xs text-zinc-400 sm:block">
-            Preview setup states
+            Toggle services
           </p>
         </div>
       </div>
 
-      <Select value={setup.id} onValueChange={handleSetupChange}>
-        <SelectTrigger
-          aria-label="Demo setup"
-          size="sm"
-          className="h-9 w-full border-white/10 bg-white/5 text-zinc-100 sm:w-52"
+      <Popover>
+        <PopoverTrigger asChild>
+          <Button
+            aria-label="Demo services"
+            variant="outline"
+            className="h-9 w-full justify-between border-white/10 bg-white/5 px-3 text-zinc-100 hover:bg-white/10 hover:text-zinc-100 sm:w-52"
+          >
+            <span className="flex min-w-0 items-center gap-2">
+              <Server className="size-3.5 shrink-0 text-zinc-400" />
+              <span className="truncate">{selectionLabel}</span>
+            </span>
+            <ChevronUp className="size-3.5 shrink-0 text-zinc-500" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent
+          align="center"
+          side="top"
+          className="w-72 border-white/10 bg-zinc-950 p-1 text-zinc-100"
         >
-          <Server className="size-3.5 text-zinc-400" />
-          <SelectValue>{setup.label}</SelectValue>
-        </SelectTrigger>
-        <SelectContent align="center" className="min-w-72">
-          {DEMO_SETUPS.map((option) => (
-            <SelectItem key={option.id} value={option.id}>
-              <span className="flex flex-col items-start">
-                <span>{option.label}</span>
-                <span className="text-muted-foreground text-xs">
-                  {option.description}
+          <div aria-label="Enabled demo services" role="group">
+            {DEMO_SERVICES.map((service) => (
+              <label
+                key={service.id}
+                htmlFor={`demo-service-${service.id}`}
+                className="flex cursor-pointer items-center gap-3 rounded-md px-3 py-2.5 hover:bg-white/5"
+              >
+                <span className="min-w-0 flex-1">
+                  <span className="block text-sm">{service.label}</span>
+                  <span className="block text-xs text-zinc-500">
+                    {service.description}
+                  </span>
                 </span>
-              </span>
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
+                <Switch
+                  id={`demo-service-${service.id}`}
+                  aria-label={`${service.label} enabled`}
+                  checked={configuration.services[service.id]}
+                  onCheckedChange={(enabled) =>
+                    setServiceEnabled(service.id, enabled)
+                  }
+                  className="data-[state=checked]:bg-amber-400"
+                />
+              </label>
+            ))}
+          </div>
+        </PopoverContent>
+      </Popover>
 
       <Button
         aria-label="Minimize demo configuration"
@@ -155,4 +185,20 @@ function DemoDevtoolsBar({
       </Button>
     </aside>
   );
+}
+
+function getSelectionLabel(enabledServiceLabels: string[]): string {
+  if (enabledServiceLabels.length === 0) {
+    return "No services";
+  }
+
+  if (enabledServiceLabels.length === DEMO_SERVICES.length) {
+    return "Complete setup";
+  }
+
+  if (enabledServiceLabels.length === 1) {
+    return enabledServiceLabels[0] ?? "1 service";
+  }
+
+  return `${enabledServiceLabels.length} services`;
 }

--- a/src/components/dashboard/server-status.tsx
+++ b/src/components/dashboard/server-status.tsx
@@ -180,7 +180,14 @@ export function ServerStatus() {
         </CardTitle>
         <CardDescription>{description}</CardDescription>
       </CardHeader>
-      <CardContent className="h-full">{content}</CardContent>
+      <CardContent
+        className={cn(
+          "flex flex-1 flex-col",
+          (isLoading || error) && "justify-center",
+        )}
+      >
+        {content}
+      </CardContent>
     </Card>
   );
 }

--- a/src/demo/config.test.ts
+++ b/src/demo/config.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_DEMO_SETUP,
+  DEMO_SETUPS,
+  DEMO_SETUP_HEADER,
+  getDemoSetup,
+  getDemoSetupFromHeaders,
+} from "~/demo/config";
+
+describe("demo configuration", () => {
+  it.each(DEMO_SETUPS)("resolves the $id preset", (setup) => {
+    expect(getDemoSetup(setup.id)).toBe(setup);
+  });
+
+  it.each([undefined, null, "unknown"])(
+    "defaults an invalid value to the complete setup",
+    (value) => {
+      expect(getDemoSetup(value)).toBe(DEFAULT_DEMO_SETUP);
+    },
+  );
+
+  it("reads the setup from the request header", () => {
+    const headers = new Headers({ [DEMO_SETUP_HEADER]: "api-only" });
+
+    expect(getDemoSetupFromHeaders(headers).id).toBe("api-only");
+  });
+});

--- a/src/demo/config.test.ts
+++ b/src/demo/config.test.ts
@@ -1,27 +1,64 @@
 import { describe, expect, it } from "vitest";
 import {
-  DEFAULT_DEMO_SETUP,
-  DEMO_SETUPS,
-  DEMO_SETUP_HEADER,
-  getDemoSetup,
-  getDemoSetupFromHeaders,
+  DEFAULT_DEMO_CONFIGURATION,
+  DEMO_CONFIGURATION_HEADER,
+  getDemoConfiguration,
+  getDemoConfigurationFromHeaders,
+  serializeDemoConfiguration,
+  type DemoConfiguration,
 } from "~/demo/config";
 
+const NO_SERVICES: DemoConfiguration = {
+  services: {
+    blockyApi: false,
+    prometheus: false,
+    queryLogs: false,
+  },
+};
+
+const API_AND_LOGS: DemoConfiguration = {
+  services: {
+    blockyApi: true,
+    prometheus: false,
+    queryLogs: true,
+  },
+};
+
 describe("demo configuration", () => {
-  it.each(DEMO_SETUPS)("resolves the $id preset", (setup) => {
-    expect(getDemoSetup(setup.id)).toBe(setup);
+  it.each([
+    [DEFAULT_DEMO_CONFIGURATION, "blockyApi,prometheus,queryLogs"],
+    [API_AND_LOGS, "blockyApi,queryLogs"],
+    [NO_SERVICES, "none"],
+  ])("serializes enabled services", (configuration, value) => {
+    expect(serializeDemoConfiguration(configuration)).toBe(value);
   });
 
-  it.each([undefined, null, "unknown"])(
-    "defaults an invalid value to the complete setup",
+  it.each([
+    ["blockyApi,prometheus,queryLogs", DEFAULT_DEMO_CONFIGURATION],
+    ["blockyApi,queryLogs", API_AND_LOGS],
+    ["none", NO_SERVICES],
+  ])("parses enabled services", (value, configuration) => {
+    expect(getDemoConfiguration(value)).toEqual(configuration);
+  });
+
+  it.each([undefined, null, "unknown", "blockyApi,unknown"])(
+    "defaults a missing or invalid value to all services",
     (value) => {
-      expect(getDemoSetup(value)).toBe(DEFAULT_DEMO_SETUP);
+      expect(getDemoConfiguration(value)).toBe(DEFAULT_DEMO_CONFIGURATION);
     },
   );
 
-  it("reads the setup from the request header", () => {
-    const headers = new Headers({ [DEMO_SETUP_HEADER]: "api-only" });
+  it("reads enabled services from the request header", () => {
+    const headers = new Headers({
+      [DEMO_CONFIGURATION_HEADER]: "prometheus,queryLogs",
+    });
 
-    expect(getDemoSetupFromHeaders(headers).id).toBe("api-only");
+    expect(getDemoConfigurationFromHeaders(headers)).toEqual({
+      services: {
+        blockyApi: false,
+        prometheus: true,
+        queryLogs: true,
+      },
+    });
   });
 });

--- a/src/demo/config.ts
+++ b/src/demo/config.ts
@@ -1,58 +1,84 @@
-export const DEMO_SETUP_HEADER = "x-blocky-demo-setup";
+export const DEMO_CONFIGURATION_HEADER = "x-blocky-demo-services";
 
-export const DEMO_SETUPS = [
+export const DEMO_SERVICES = [
   {
-    id: "complete",
-    label: "Complete setup",
-    description: "Blocky API, Prometheus, and query logs",
-    services: {
-      blockyApi: true,
-      prometheus: true,
-      queryLogs: true,
-    },
+    id: "blockyApi",
+    label: "Blocky API",
+    description: "Status, controls, and query tool",
   },
   {
-    id: "without-logs",
-    label: "Without query logs",
-    description: "Blocky API and Prometheus only",
-    services: {
-      blockyApi: true,
-      prometheus: true,
-      queryLogs: false,
-    },
+    id: "prometheus",
+    label: "Prometheus",
+    description: "Metrics and overview statistics",
   },
   {
-    id: "api-only",
-    label: "API only",
-    description: "No Prometheus or query log provider",
-    services: {
-      blockyApi: true,
-      prometheus: false,
-      queryLogs: false,
-    },
-  },
-  {
-    id: "offline",
-    label: "Blocky offline",
-    description: "Simulate an unreachable Blocky instance",
-    services: {
-      blockyApi: false,
-      prometheus: false,
-      queryLogs: false,
-    },
+    id: "queryLogs",
+    label: "Query logs",
+    description: "Charts and query history",
   },
 ] as const;
 
-export type DemoSetup = (typeof DEMO_SETUPS)[number];
-export type DemoSetupId = DemoSetup["id"];
-export type DemoService = keyof DemoSetup["services"];
+export type DemoService = (typeof DEMO_SERVICES)[number]["id"];
 
-export const DEFAULT_DEMO_SETUP = DEMO_SETUPS[0];
+export type DemoConfiguration = {
+  services: Record<DemoService, boolean>;
+};
 
-export function getDemoSetup(value: string | null | undefined): DemoSetup {
-  return DEMO_SETUPS.find((setup) => setup.id === value) ?? DEFAULT_DEMO_SETUP;
+export const DEFAULT_DEMO_CONFIGURATION: DemoConfiguration = {
+  services: {
+    blockyApi: true,
+    prometheus: true,
+    queryLogs: true,
+  },
+};
+
+export function serializeDemoConfiguration(
+  configuration: DemoConfiguration,
+): string {
+  const enabledServices = DEMO_SERVICES.flatMap(({ id }) =>
+    configuration.services[id] ? [id] : [],
+  );
+
+  return enabledServices.length > 0 ? enabledServices.join(",") : "none";
 }
 
-export function getDemoSetupFromHeaders(headers: Headers): DemoSetup {
-  return getDemoSetup(headers.get(DEMO_SETUP_HEADER));
+export function getDemoConfiguration(
+  value: string | null | undefined,
+): DemoConfiguration {
+  if (value === null || value === undefined) {
+    return DEFAULT_DEMO_CONFIGURATION;
+  }
+
+  if (value === "none") {
+    return createDemoConfiguration(new Set());
+  }
+
+  const serviceIds = value.split(",");
+  const knownServices = new Set<string>(
+    DEMO_SERVICES.map((service) => service.id),
+  );
+
+  if (serviceIds.some((serviceId) => !knownServices.has(serviceId))) {
+    return DEFAULT_DEMO_CONFIGURATION;
+  }
+
+  return createDemoConfiguration(new Set(serviceIds));
+}
+
+export function getDemoConfigurationFromHeaders(
+  headers: Headers,
+): DemoConfiguration {
+  return getDemoConfiguration(headers.get(DEMO_CONFIGURATION_HEADER));
+}
+
+function createDemoConfiguration(
+  enabledServices: ReadonlySet<string>,
+): DemoConfiguration {
+  return {
+    services: {
+      blockyApi: enabledServices.has("blockyApi"),
+      prometheus: enabledServices.has("prometheus"),
+      queryLogs: enabledServices.has("queryLogs"),
+    },
+  };
 }

--- a/src/demo/config.ts
+++ b/src/demo/config.ts
@@ -1,0 +1,58 @@
+export const DEMO_SETUP_HEADER = "x-blocky-demo-setup";
+
+export const DEMO_SETUPS = [
+  {
+    id: "complete",
+    label: "Complete setup",
+    description: "Blocky API, Prometheus, and query logs",
+    services: {
+      blockyApi: true,
+      prometheus: true,
+      queryLogs: true,
+    },
+  },
+  {
+    id: "without-logs",
+    label: "Without query logs",
+    description: "Blocky API and Prometheus only",
+    services: {
+      blockyApi: true,
+      prometheus: true,
+      queryLogs: false,
+    },
+  },
+  {
+    id: "api-only",
+    label: "API only",
+    description: "No Prometheus or query log provider",
+    services: {
+      blockyApi: true,
+      prometheus: false,
+      queryLogs: false,
+    },
+  },
+  {
+    id: "offline",
+    label: "Blocky offline",
+    description: "Simulate an unreachable Blocky instance",
+    services: {
+      blockyApi: false,
+      prometheus: false,
+      queryLogs: false,
+    },
+  },
+] as const;
+
+export type DemoSetup = (typeof DEMO_SETUPS)[number];
+export type DemoSetupId = DemoSetup["id"];
+export type DemoService = keyof DemoSetup["services"];
+
+export const DEFAULT_DEMO_SETUP = DEMO_SETUPS[0];
+
+export function getDemoSetup(value: string | null | undefined): DemoSetup {
+  return DEMO_SETUPS.find((setup) => setup.id === value) ?? DEFAULT_DEMO_SETUP;
+}
+
+export function getDemoSetupFromHeaders(headers: Headers): DemoSetup {
+  return getDemoSetup(headers.get(DEMO_SETUP_HEADER));
+}

--- a/src/demo/context.tsx
+++ b/src/demo/context.tsx
@@ -2,42 +2,71 @@
 
 import {
   createContext,
-  type Dispatch,
   type ReactNode,
-  type SetStateAction,
+  useCallback,
   useContext,
   useMemo,
   useState,
 } from "react";
-import { DEFAULT_DEMO_SETUP, type DemoSetup } from "~/demo/config";
+import {
+  DEFAULT_DEMO_CONFIGURATION,
+  type DemoConfiguration,
+  type DemoService,
+} from "~/demo/config";
 
-type DemoModeContextValue = {
-  setup: DemoSetup;
-  setSetup: Dispatch<SetStateAction<DemoSetup>>;
+type DemoConfigurationContextValue = {
+  configuration: DemoConfiguration;
+  setServiceEnabled: (service: DemoService, enabled: boolean) => void;
 };
 
-const DemoModeContext = createContext<DemoModeContextValue | null>(null);
+const DemoConfigurationContext =
+  createContext<DemoConfigurationContextValue | null>(null);
 
-export function DemoSetupProvider({ children }: { children: ReactNode }) {
-  const [setup, setSetup] = useState<DemoSetup>(DEFAULT_DEMO_SETUP);
-  const value = useMemo(() => ({ setup, setSetup }), [setup]);
+export function DemoConfigurationProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const [configuration, setConfiguration] = useState<DemoConfiguration>(
+    DEFAULT_DEMO_CONFIGURATION,
+  );
+  const setServiceEnabled = useCallback(
+    (service: DemoService, enabled: boolean) => {
+      setConfiguration((current) => ({
+        services: {
+          ...current.services,
+          [service]: enabled,
+        },
+      }));
+    },
+    [],
+  );
+  const value = useMemo(
+    () => ({ configuration, setServiceEnabled }),
+    [configuration, setServiceEnabled],
+  );
 
   return (
-    <DemoModeContext.Provider value={value}>
+    <DemoConfigurationContext.Provider value={value}>
       {children}
-    </DemoModeContext.Provider>
+    </DemoConfigurationContext.Provider>
   );
 }
 
-export function useDemoSetup(): DemoSetup {
-  return useContext(DemoModeContext)?.setup ?? DEFAULT_DEMO_SETUP;
+export function useDemoConfiguration(): DemoConfiguration {
+  return (
+    useContext(DemoConfigurationContext)?.configuration ??
+    DEFAULT_DEMO_CONFIGURATION
+  );
 }
 
-export function useDemoSetupController(): DemoModeContextValue {
-  const context = useContext(DemoModeContext);
+export function useDemoConfigurationController(): DemoConfigurationContextValue {
+  const context = useContext(DemoConfigurationContext);
 
   if (!context) {
-    throw new Error("Demo setup controls require DemoSetupProvider.");
+    throw new Error(
+      "Demo configuration controls require DemoConfigurationProvider.",
+    );
   }
 
   return context;

--- a/src/demo/context.tsx
+++ b/src/demo/context.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import {
+  createContext,
+  type Dispatch,
+  type ReactNode,
+  type SetStateAction,
+  useContext,
+  useMemo,
+  useState,
+} from "react";
+import { DEFAULT_DEMO_SETUP, type DemoSetup } from "~/demo/config";
+
+type DemoModeContextValue = {
+  setup: DemoSetup;
+  setSetup: Dispatch<SetStateAction<DemoSetup>>;
+};
+
+const DemoModeContext = createContext<DemoModeContextValue | null>(null);
+
+export function DemoSetupProvider({ children }: { children: ReactNode }) {
+  const [setup, setSetup] = useState<DemoSetup>(DEFAULT_DEMO_SETUP);
+  const value = useMemo(() => ({ setup, setSetup }), [setup]);
+
+  return (
+    <DemoModeContext.Provider value={value}>
+      {children}
+    </DemoModeContext.Provider>
+  );
+}
+
+export function useDemoSetup(): DemoSetup {
+  return useContext(DemoModeContext)?.setup ?? DEFAULT_DEMO_SETUP;
+}
+
+export function useDemoSetupController(): DemoModeContextValue {
+  const context = useContext(DemoModeContext);
+
+  if (!context) {
+    throw new Error("Demo setup controls require DemoSetupProvider.");
+  }
+
+  return context;
+}

--- a/src/server/api/demo-config.test.ts
+++ b/src/server/api/demo-config.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { DEMO_SETUPS, DEMO_SETUP_HEADER } from "~/demo/config";
+import { DEMO_CONFIGURATION_HEADER } from "~/demo/config";
 
 const mocks = vi.hoisted(() => {
   const logProvider = {};
@@ -26,11 +26,11 @@ import { blockyRouter } from "~/server/api/routers/blocky";
 import { statsRouter } from "~/server/api/routers/stats";
 import { createTRPCContext } from "~/server/api/trpc";
 
-function createHeaders(setupId?: string): Headers {
+function createHeaders(enabledServices?: string): Headers {
   const headers = new Headers();
 
-  if (setupId) {
-    headers.set(DEMO_SETUP_HEADER, setupId);
+  if (enabledServices) {
+    headers.set(DEMO_CONFIGURATION_HEADER, enabledServices);
   }
 
   return headers;
@@ -41,35 +41,37 @@ describe("demo request configuration", () => {
     mocks.createLogProvider.mockClear();
   });
 
-  it.each(DEMO_SETUPS)("applies the $id service policy", async (setup) => {
-    const context = await createTRPCContext({
-      headers: createHeaders(setup.id),
-    });
+  it.each([
+    ["blockyApi", true, false, false],
+    ["prometheus", false, true, false],
+    ["queryLogs", false, false, true],
+    ["none", false, false, false],
+  ])(
+    "enables services independently for %s",
+    async (enabledServices, blockyApi, prometheus, queryLogs) => {
+      const context = await createTRPCContext({
+        headers: createHeaders(enabledServices),
+      });
 
-    expect(context.isDemoServiceAvailable("blockyApi")).toBe(
-      setup.services.blockyApi,
-    );
-    expect(context.isDemoServiceAvailable("prometheus")).toBe(
-      setup.services.prometheus,
-    );
-    expect(context.isDemoServiceAvailable("queryLogs")).toBe(
-      setup.services.queryLogs,
-    );
+      expect(context.isDemoServiceAvailable("blockyApi")).toBe(blockyApi);
+      expect(context.isDemoServiceAvailable("prometheus")).toBe(prometheus);
+      expect(context.isDemoServiceAvailable("queryLogs")).toBe(queryLogs);
 
-    if (setup.services.queryLogs) {
-      expect(context.logProvider).toBe(mocks.logProvider);
-      expect(mocks.createLogProvider).toHaveBeenCalledOnce();
-    } else {
-      expect(context.logProvider).toBeUndefined();
-      expect(mocks.createLogProvider).not.toHaveBeenCalled();
-    }
-  });
+      if (queryLogs) {
+        expect(context.logProvider).toBe(mocks.logProvider);
+        expect(mocks.createLogProvider).toHaveBeenCalledOnce();
+      } else {
+        expect(context.logProvider).toBeUndefined();
+        expect(mocks.createLogProvider).not.toHaveBeenCalled();
+      }
+    },
+  );
 
   it.each([undefined, "invalid"])(
-    "uses the complete setup for a missing or invalid header",
-    async (setupId) => {
+    "enables every service for a missing or invalid header",
+    async (enabledServices) => {
       const context = await createTRPCContext({
-        headers: createHeaders(setupId),
+        headers: createHeaders(enabledServices),
       });
 
       expect(context.isDemoServiceAvailable("blockyApi")).toBe(true);
@@ -79,9 +81,9 @@ describe("demo request configuration", () => {
     },
   );
 
-  it("returns the real unavailable states for the offline setup", async () => {
+  it("returns the real unavailable states when services are disabled", async () => {
     const context = await createTRPCContext({
-      headers: createHeaders("offline"),
+      headers: createHeaders("none"),
     });
     const blockyCaller = blockyRouter.createCaller(context);
     const statsCaller = statsRouter.createCaller(context);

--- a/src/server/api/demo-config.test.ts
+++ b/src/server/api/demo-config.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DEMO_SETUPS, DEMO_SETUP_HEADER } from "~/demo/config";
+
+const mocks = vi.hoisted(() => {
+  const logProvider = {};
+
+  return {
+    logProvider,
+    createLogProvider: vi.fn(async () => logProvider),
+  };
+});
+
+vi.mock("~/env", () => ({
+  env: {
+    BLOCKY_API_URL: "http://localhost:4000",
+    BLOCKY_REQUEST_HEADERS: undefined,
+    DEMO_MODE: true,
+  },
+}));
+
+vi.mock("~/server/logs", () => ({
+  createLogProvider: mocks.createLogProvider,
+}));
+
+import { blockyRouter } from "~/server/api/routers/blocky";
+import { statsRouter } from "~/server/api/routers/stats";
+import { createTRPCContext } from "~/server/api/trpc";
+
+function createHeaders(setupId?: string): Headers {
+  const headers = new Headers();
+
+  if (setupId) {
+    headers.set(DEMO_SETUP_HEADER, setupId);
+  }
+
+  return headers;
+}
+
+describe("demo request configuration", () => {
+  beforeEach(() => {
+    mocks.createLogProvider.mockClear();
+  });
+
+  it.each(DEMO_SETUPS)("applies the $id service policy", async (setup) => {
+    const context = await createTRPCContext({
+      headers: createHeaders(setup.id),
+    });
+
+    expect(context.isDemoServiceAvailable("blockyApi")).toBe(
+      setup.services.blockyApi,
+    );
+    expect(context.isDemoServiceAvailable("prometheus")).toBe(
+      setup.services.prometheus,
+    );
+    expect(context.isDemoServiceAvailable("queryLogs")).toBe(
+      setup.services.queryLogs,
+    );
+
+    if (setup.services.queryLogs) {
+      expect(context.logProvider).toBe(mocks.logProvider);
+      expect(mocks.createLogProvider).toHaveBeenCalledOnce();
+    } else {
+      expect(context.logProvider).toBeUndefined();
+      expect(mocks.createLogProvider).not.toHaveBeenCalled();
+    }
+  });
+
+  it.each([undefined, "invalid"])(
+    "uses the complete setup for a missing or invalid header",
+    async (setupId) => {
+      const context = await createTRPCContext({
+        headers: createHeaders(setupId),
+      });
+
+      expect(context.isDemoServiceAvailable("blockyApi")).toBe(true);
+      expect(context.isDemoServiceAvailable("prometheus")).toBe(true);
+      expect(context.isDemoServiceAvailable("queryLogs")).toBe(true);
+      expect(context.logProvider).toBe(mocks.logProvider);
+    },
+  );
+
+  it("returns the real unavailable states for the offline setup", async () => {
+    const context = await createTRPCContext({
+      headers: createHeaders("offline"),
+    });
+    const blockyCaller = blockyRouter.createCaller(context);
+    const statsCaller = statsRouter.createCaller(context);
+
+    await expect(blockyCaller.blockingStatus()).rejects.toThrow(
+      "Unable to reach Blocky API at http://localhost:4000. Please check if the API server is running.",
+    );
+    await expect(statsCaller.prometheusStatus()).resolves.toEqual({
+      available: false,
+    });
+    await expect(statsCaller.overview()).resolves.toBeNull();
+  });
+});

--- a/src/server/api/demo-config.test.ts
+++ b/src/server/api/demo-config.test.ts
@@ -88,9 +88,11 @@ describe("demo request configuration", () => {
     const blockyCaller = blockyRouter.createCaller(context);
     const statsCaller = statsRouter.createCaller(context);
 
-    await expect(blockyCaller.blockingStatus()).rejects.toThrow(
-      "Unable to reach Blocky API at http://localhost:4000. Please check if the API server is running.",
-    );
+    await expect(blockyCaller.blockingStatus()).rejects.toMatchObject({
+      code: "SERVICE_UNAVAILABLE",
+      message:
+        "Unable to reach Blocky API at http://localhost:4000. Please check if the API server is running.",
+    });
     await expect(statsCaller.prometheusStatus()).resolves.toEqual({
       available: false,
     });

--- a/src/server/api/demo.ts
+++ b/src/server/api/demo.ts
@@ -1,11 +1,15 @@
+import { TRPCError } from "@trpc/server";
 import { env } from "~/env";
 import { publicProcedure } from "~/server/api/trpc";
 
+export const BLOCKY_API_UNAVAILABLE_MESSAGE = `Unable to reach Blocky API at ${env.BLOCKY_API_URL}. Please check if the API server is running.`;
+
 export const blockyApiProcedure = publicProcedure.use(async ({ ctx, next }) => {
   if (!ctx.isDemoServiceAvailable("blockyApi")) {
-    throw new Error(
-      `Unable to reach Blocky API at ${env.BLOCKY_API_URL}. Please check if the API server is running.`,
-    );
+    throw new TRPCError({
+      code: "SERVICE_UNAVAILABLE",
+      message: BLOCKY_API_UNAVAILABLE_MESSAGE,
+    });
   }
 
   return next();

--- a/src/server/api/demo.ts
+++ b/src/server/api/demo.ts
@@ -1,0 +1,12 @@
+import { env } from "~/env";
+import { publicProcedure } from "~/server/api/trpc";
+
+export const blockyApiProcedure = publicProcedure.use(async ({ ctx, next }) => {
+  if (!ctx.isDemoServiceAvailable("blockyApi")) {
+    throw new Error(
+      `Unable to reach Blocky API at ${env.BLOCKY_API_URL}. Please check if the API server is running.`,
+    );
+  }
+
+  return next();
+});

--- a/src/server/api/routers/blocky.ts
+++ b/src/server/api/routers/blocky.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { env } from "~/env";
 import { createTRPCRouter, publicProcedure } from "~/server/api/trpc";
+import { blockyApiProcedure } from "~/server/api/demo";
 import ky from "ky";
 import {
   BLOCKY_DNS_RECORD_TYPES,
@@ -34,7 +35,7 @@ const api = ky.create({
 });
 
 export const blockyRouter = createTRPCRouter({
-  blockingStatus: publicProcedure.query(async () => {
+  blockingStatus: blockyApiProcedure.query(async () => {
     try {
       const response = await api.get("api/blocking/status");
 
@@ -67,14 +68,14 @@ export const blockyRouter = createTRPCRouter({
       );
     }
   }),
-  blockingEnable: publicProcedure.mutation(async () => {
+  blockingEnable: blockyApiProcedure.mutation(async () => {
     const response = await api.get("api/blocking/enable");
     if (!response.ok) {
       throw new Error(`Failed to enable blocking: ${response.statusText}`);
     }
     return { success: true };
   }),
-  blockingDisable: publicProcedure
+  blockingDisable: blockyApiProcedure
     .input(
       z
         .object({
@@ -99,7 +100,7 @@ export const blockyRouter = createTRPCRouter({
 
       return { success: true };
     }),
-  cacheClear: publicProcedure.mutation(async () => {
+  cacheClear: blockyApiProcedure.mutation(async () => {
     const response = await api.post("api/cache/flush");
 
     if (!response.ok) {
@@ -108,7 +109,7 @@ export const blockyRouter = createTRPCRouter({
 
     return { success: true };
   }),
-  listsRefresh: publicProcedure.mutation(async () => {
+  listsRefresh: blockyApiProcedure.mutation(async () => {
     const response = await api.post("api/lists/refresh");
 
     if (!response.ok) {
@@ -117,7 +118,7 @@ export const blockyRouter = createTRPCRouter({
 
     return { success: true };
   }),
-  queryExecute: publicProcedure
+  queryExecute: blockyApiProcedure
     .input(queryRequestSchema)
     .mutation(async ({ input }) => {
       const response = await api.post("api/query", {

--- a/src/server/api/routers/blocky.ts
+++ b/src/server/api/routers/blocky.ts
@@ -1,7 +1,10 @@
 import { z } from "zod";
 import { env } from "~/env";
 import { createTRPCRouter, publicProcedure } from "~/server/api/trpc";
-import { blockyApiProcedure } from "~/server/api/demo";
+import {
+  BLOCKY_API_UNAVAILABLE_MESSAGE,
+  blockyApiProcedure,
+} from "~/server/api/demo";
 import ky from "ky";
 import {
   BLOCKY_DNS_RECORD_TYPES,
@@ -55,9 +58,7 @@ export const blockyRouter = createTRPCRouter({
           error.message.includes("fetch failed") ||
           error.message.includes("NetworkError")
         ) {
-          throw new Error(
-            `Unable to reach Blocky API at ${env.BLOCKY_API_URL}. Please check if the API server is running.`,
-          );
+          throw new Error(BLOCKY_API_UNAVAILABLE_MESSAGE);
         }
 
         throw error;

--- a/src/server/api/routers/stats.ts
+++ b/src/server/api/routers/stats.ts
@@ -23,12 +23,20 @@ const searchSchema = z.object({
 });
 
 export const statsRouter = createTRPCRouter({
-  prometheusStatus: publicProcedure.query(async () => {
+  prometheusStatus: publicProcedure.query(async ({ ctx }) => {
+    if (!ctx.isDemoServiceAvailable("prometheus")) {
+      return { available: false };
+    }
+
     const available = await checkPrometheusAvailable();
     return { available };
   }),
 
   overview: publicProcedure.query(async ({ ctx }) => {
+    if (!ctx.isDemoServiceAvailable("prometheus")) {
+      return null;
+    }
+
     const parsed = await fetchPrometheusMetrics();
     if (!parsed) return null;
 

--- a/src/server/api/trpc.ts
+++ b/src/server/api/trpc.ts
@@ -13,9 +13,9 @@ import { ZodError, z } from "zod";
 import { createLogProvider } from "~/server/logs";
 import { env } from "~/env";
 import {
-  DEFAULT_DEMO_SETUP,
+  DEFAULT_DEMO_CONFIGURATION,
   type DemoService,
-  getDemoSetupFromHeaders,
+  getDemoConfigurationFromHeaders,
 } from "~/demo/config";
 
 /**
@@ -31,11 +31,11 @@ import {
  * @see https://trpc.io/docs/server/context
  */
 export const createTRPCContext = async (opts: { headers: Headers }) => {
-  const demoSetup = env.DEMO_MODE
-    ? getDemoSetupFromHeaders(opts.headers)
-    : DEFAULT_DEMO_SETUP;
+  const demoConfiguration = env.DEMO_MODE
+    ? getDemoConfigurationFromHeaders(opts.headers)
+    : DEFAULT_DEMO_CONFIGURATION;
   const isDemoServiceAvailable = (service: DemoService) =>
-    demoSetup.services[service];
+    demoConfiguration.services[service];
   const logProvider = isDemoServiceAvailable("queryLogs")
     ? await createLogProvider()
     : undefined;

--- a/src/server/api/trpc.ts
+++ b/src/server/api/trpc.ts
@@ -11,6 +11,12 @@ import superjson from "superjson";
 import { ZodError, z } from "zod";
 
 import { createLogProvider } from "~/server/logs";
+import { env } from "~/env";
+import {
+  DEFAULT_DEMO_SETUP,
+  type DemoService,
+  getDemoSetupFromHeaders,
+} from "~/demo/config";
 
 /**
  * 1. CONTEXT
@@ -25,9 +31,17 @@ import { createLogProvider } from "~/server/logs";
  * @see https://trpc.io/docs/server/context
  */
 export const createTRPCContext = async (opts: { headers: Headers }) => {
-  const logProvider = await createLogProvider();
+  const demoSetup = env.DEMO_MODE
+    ? getDemoSetupFromHeaders(opts.headers)
+    : DEFAULT_DEMO_SETUP;
+  const isDemoServiceAvailable = (service: DemoService) =>
+    demoSetup.services[service];
+  const logProvider = isDemoServiceAvailable("queryLogs")
+    ? await createLogProvider()
+    : undefined;
 
   return {
+    isDemoServiceAvailable,
     logProvider,
     ...opts,
   };

--- a/src/trpc/react.tsx
+++ b/src/trpc/react.tsx
@@ -10,7 +10,7 @@ import SuperJSON from "superjson";
 
 import { type AppRouter } from "./app-router";
 import { createQueryClient } from "./query-client";
-import { DEMO_SETUP_HEADER, type DemoSetupId } from "~/demo/config";
+import { DEMO_CONFIGURATION_HEADER } from "~/demo/config";
 
 let clientQueryClientSingleton: QueryClient | undefined = undefined;
 const getQueryClient = () => {
@@ -44,10 +44,10 @@ export type RouterOutputs = inferRouterOutputs<AppRouter>;
 
 export function TRPCReactProvider({
   children,
-  demoSetupId,
+  demoConfiguration,
 }: {
   children: React.ReactNode;
-  demoSetupId?: DemoSetupId;
+  demoConfiguration?: string;
 }) {
   const queryClient = getQueryClient();
 
@@ -66,15 +66,15 @@ export function TRPCReactProvider({
             headers: () => {
               const headers = new Headers();
               headers.set("x-trpc-source", "nextjs-react");
-              if (demoSetupId) {
-                headers.set(DEMO_SETUP_HEADER, demoSetupId);
+              if (demoConfiguration) {
+                headers.set(DEMO_CONFIGURATION_HEADER, demoConfiguration);
               }
               return headers;
             },
           }),
         ],
       }),
-    [demoSetupId],
+    [demoConfiguration],
   );
 
   return (

--- a/src/trpc/react.tsx
+++ b/src/trpc/react.tsx
@@ -5,11 +5,12 @@ import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { httpBatchStreamLink, loggerLink } from "@trpc/client";
 import { createTRPCReact } from "@trpc/react-query";
 import { type inferRouterInputs, type inferRouterOutputs } from "@trpc/server";
-import { useState } from "react";
+import { useMemo } from "react";
 import SuperJSON from "superjson";
 
 import { type AppRouter } from "./app-router";
 import { createQueryClient } from "./query-client";
+import { DEMO_SETUP_HEADER, type DemoSetupId } from "~/demo/config";
 
 let clientQueryClientSingleton: QueryClient | undefined = undefined;
 const getQueryClient = () => {
@@ -41,34 +42,45 @@ export type RouterInputs = inferRouterInputs<AppRouter>;
  */
 export type RouterOutputs = inferRouterOutputs<AppRouter>;
 
-export function TRPCReactProvider(props: { children: React.ReactNode }) {
+export function TRPCReactProvider({
+  children,
+  demoSetupId,
+}: {
+  children: React.ReactNode;
+  demoSetupId?: DemoSetupId;
+}) {
   const queryClient = getQueryClient();
 
-  const [trpcClient] = useState(() =>
-    api.createClient({
-      links: [
-        loggerLink({
-          enabled: (op) =>
-            process.env.NODE_ENV === "development" ||
-            (op.direction === "down" && op.result instanceof Error),
-        }),
-        httpBatchStreamLink({
-          transformer: SuperJSON,
-          url: getBaseUrl() + "/api/trpc",
-          headers: () => {
-            const headers = new Headers();
-            headers.set("x-trpc-source", "nextjs-react");
-            return headers;
-          },
-        }),
-      ],
-    }),
+  const trpcClient = useMemo(
+    () =>
+      api.createClient({
+        links: [
+          loggerLink({
+            enabled: (op) =>
+              process.env.NODE_ENV === "development" ||
+              (op.direction === "down" && op.result instanceof Error),
+          }),
+          httpBatchStreamLink({
+            transformer: SuperJSON,
+            url: getBaseUrl() + "/api/trpc",
+            headers: () => {
+              const headers = new Headers();
+              headers.set("x-trpc-source", "nextjs-react");
+              if (demoSetupId) {
+                headers.set(DEMO_SETUP_HEADER, demoSetupId);
+              }
+              return headers;
+            },
+          }),
+        ],
+      }),
+    [demoSetupId],
   );
 
   return (
     <QueryClientProvider client={queryClient}>
       <api.Provider client={trpcClient} queryClient={queryClient}>
-        {props.children}
+        {children}
       </api.Provider>
       <ReactQueryDevtools initialIsOpen={false} />
     </QueryClientProvider>


### PR DESCRIPTION
## Summary

- Add configurable demo setups for complete, API-only, no-logs, and offline states.
- Add a collapsible demo configuration bar for switching service scenarios at runtime.
- Route demo setup headers through tRPC and conditionally enable API, Prometheus, and query log services.
- Add coverage for demo configuration resolution and service behavior.
- Improve server status content layout for loading and error states.

<img width="340" height="176" alt="image" src="https://github.com/user-attachments/assets/7b1768d7-b12c-4ff9-84d6-0522221b2655" />
<img width="481" height="276" alt="image" src="https://github.com/user-attachments/assets/d9c68bd3-2526-4209-88a9-693589048de9" />



## Testing

- `bun run verify`
- Demo configuration unit tests
- Demo request configuration and offline behavior tests