### PR TITLE
Remove deprecated query log and Docker Hub compatibility

### DIFF
--- a/.changeset/chilly-chicken-accept.md
+++ b/.changeset/chilly-chicken-accept.md
@@ -1,0 +1,24 @@
+---
+"blocky-ui": major
+---
+
+Remove deprecated configuration and distribution compatibility.
+
+#### Breaking changes
+
+##### Query log configuration
+
+`DATABASE_URL` has been deprecated since v1.2.0 and is now no longer accepted. Configure the query log provider explicitly:
+
+```env
+QUERY_LOG_TYPE=mysql
+QUERY_LOG_TARGET=mysql://username:password@localhost:3306/blocky_query_log
+```
+
+##### Container registry
+
+The Docker Hub image (`gabrielduartem/blocky-ui`) has been deprecated since v1.4.0 and will no longer receive updates. Pull releases from GitHub Container Registry instead:
+
+```yaml
+image: ghcr.io/gabeduartem/blocky-ui:v2.0.0 # or :latest
+```

--- a/.github/actions/publish-docker-image/action.yml
+++ b/.github/actions/publish-docker-image/action.yml
@@ -6,12 +6,6 @@ inputs:
     description: Docker build context path.
     required: false
     default: "."
-  dockerhub-password:
-    description: DockerHub password or token. Omit to skip DockerHub login.
-    required: false
-  dockerhub-username:
-    description: DockerHub username. Omit to skip DockerHub login.
-    required: false
   ghcr-token:
     description: GitHub token with package write permission.
     required: true
@@ -44,13 +38,6 @@ runs:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
         password: ${{ inputs.ghcr-token }}
-
-    - name: Log in to DockerHub
-      if: inputs.dockerhub-username != '' && inputs.dockerhub-password != ''
-      uses: docker/login-action@v4
-      with:
-        username: ${{ inputs.dockerhub-username }}
-        password: ${{ inputs.dockerhub-password }}
 
     - name: Build and publish image
       uses: docker/build-push-action@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,6 @@ on:
 env:
   CI: true
   GHCR_IMAGE: ghcr.io/gabeduartem/blocky-ui
-  DOCKERHUB_IMAGE: gabrielduartem/blocky-ui
 
 jobs:
   release:
@@ -85,13 +84,9 @@ jobs:
         with:
           ghcr-token: ${{ secrets.GITHUB_TOKEN }}
           cache-ref: ${{ env.GHCR_IMAGE }}:buildcache
-          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
-          dockerhub-password: ${{ secrets.DOCKERHUB_TOKEN }}
           tags: |
             ${{ env.GHCR_IMAGE }}:latest
             ${{ env.GHCR_IMAGE }}:${{ matrix.package.version }}
-            ${{ env.DOCKERHUB_IMAGE }}:latest
-            ${{ env.DOCKERHUB_IMAGE }}:${{ matrix.package.version }}
 
   cleanup-failed-release:
     name: Cleanup Failed Release

--- a/src/env.js
+++ b/src/env.js
@@ -7,7 +7,6 @@ export const env = createEnv({
    * isn't built with invalid env vars.
    */
   server: {
-    DATABASE_URL: z.string().optional().meta({ deprecated: true }),
     QUERY_LOG_TYPE: z
       .enum([
         "mysql",
@@ -46,12 +45,9 @@ export const env = createEnv({
    * middlewares) or client-side so we need to destruct manually.
    */
   runtimeEnv: {
-    DATABASE_URL: process.env.DATABASE_URL,
-    QUERY_LOG_TYPE:
-      process.env.QUERY_LOG_TYPE ??
-      (process.env.DATABASE_URL ? "mysql" : undefined),
+    QUERY_LOG_TYPE: process.env.QUERY_LOG_TYPE,
     QUERY_LOG_CONSOLE_PROVIDER: process.env.QUERY_LOG_CONSOLE_PROVIDER,
-    QUERY_LOG_TARGET: process.env.QUERY_LOG_TARGET ?? process.env.DATABASE_URL,
+    QUERY_LOG_TARGET: process.env.QUERY_LOG_TARGET,
     NODE_ENV: process.env.NODE_ENV,
     BLOCKY_API_URL: process.env.BLOCKY_API_URL,
     BLOCKY_REQUEST_HEADERS: process.env.BLOCKY_REQUEST_HEADERS,

--- a/src/server/logs/index.ts
+++ b/src/server/logs/index.ts
@@ -31,12 +31,6 @@ export async function createLogProvider(): Promise<LogProvider | undefined> {
 }
 
 async function initializeLogProvider(): Promise<LogProvider | undefined> {
-  if (env.DATABASE_URL) {
-    console.warn(
-      "⚠️  DEPRECATION WARNING: DATABASE_URL is deprecated. Please use QUERY_LOG_TYPE and QUERY_LOG_TARGET instead.",
-    );
-  }
-
   if (env.DEMO_MODE) {
     console.log("Using log provider type: demo");
     return new DemoLogProvider();


### PR DESCRIPTION
## Summary
- Remove support for the deprecated `DATABASE_URL` query log configuration.
- Require explicit query log provider and target configuration.
- Remove Docker Hub publishing and retain GitHub Container Registry releases.
- Add major-version changeset documenting the breaking changes.

## Testing
- Not run.