### PR TITLE
Optimize Docker image caching across CI workflows

### DIFF
--- a/.github/actions/publish-docker-image/action.yml
+++ b/.github/actions/publish-docker-image/action.yml
@@ -10,8 +10,14 @@ inputs:
     description: GitHub token with package write permission.
     required: true
   cache-ref:
-    description: BuildKit registry cache reference.
+    description: Shared BuildKit registry cache reference.
     required: true
+  cache-policy:
+    description: Cache policy. Use shared for the registry writer, scoped for PR caches, or read-only for registry consumers.
+    required: true
+  cache-scope:
+    description: GitHub Actions cache scope used by the scoped cache policy.
+    required: false
   labels:
     description: Docker image labels.
     required: false
@@ -39,6 +45,79 @@ runs:
         username: ${{ github.repository_owner }}
         password: ${{ inputs.ghcr-token }}
 
+    - name: Resolve native dependency versions
+      id: native-dependencies
+      shell: bash
+      working-directory: ${{ inputs.context }}
+      run: |
+        set -euo pipefail
+
+        better_sqlite3="$(jq -er '.dependencies["better-sqlite3"] | select(type == "string")' package.json)"
+        if [[ ! "${better_sqlite3}" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?$ ]]; then
+          echo "better-sqlite3 must use an exact semantic version" >&2
+          exit 1
+        fi
+
+        echo "better_sqlite3=${better_sqlite3}" >> "${GITHUB_OUTPUT}"
+
+    - name: Configure build cache
+      id: cache
+      shell: bash
+      env:
+        CACHE_POLICY: ${{ inputs.cache-policy }}
+        CACHE_REF: ${{ inputs.cache-ref }}
+        CACHE_SCOPE: ${{ inputs.cache-scope }}
+        PLATFORMS: ${{ inputs.platforms }}
+      run: |
+        set -euo pipefail
+
+        if [[ -n "${CACHE_SCOPE}" && ! "${CACHE_SCOPE}" =~ ^[0-9A-Za-z._-]+$ ]]; then
+          echo "cache-scope contains unsupported characters" >&2
+          exit 1
+        fi
+
+        case "${CACHE_POLICY}" in
+          scoped)
+            if [[ -z "${CACHE_SCOPE}" ]]; then
+              echo "cache-scope is required for the scoped cache policy" >&2
+              exit 1
+            fi
+
+            platform_hash="$(printf '%s' "${PLATFORMS}" | sha256sum | cut -c1-12)"
+            effective_scope="${CACHE_SCOPE}-${platform_hash}"
+            {
+              echo "from<<EOF"
+              echo "type=gha,scope=${effective_scope}"
+              echo "type=registry,ref=${CACHE_REF}"
+              echo "EOF"
+              echo "to=type=gha,scope=${effective_scope},mode=max"
+            } >> "${GITHUB_OUTPUT}"
+            ;;
+          shared)
+            if [[ -n "${CACHE_SCOPE}" ]]; then
+              echo "cache-scope is only supported by the scoped cache policy" >&2
+              exit 1
+            fi
+
+            {
+              echo "from=type=registry,ref=${CACHE_REF}"
+              echo "to=type=registry,ref=${CACHE_REF},mode=max"
+            } >> "${GITHUB_OUTPUT}"
+            ;;
+          read-only)
+            if [[ -n "${CACHE_SCOPE}" ]]; then
+              echo "cache-scope is only supported by the scoped cache policy" >&2
+              exit 1
+            fi
+
+            echo "from=type=registry,ref=${CACHE_REF}" >> "${GITHUB_OUTPUT}"
+            ;;
+          *)
+            echo "cache-policy must be shared, scoped, or read-only" >&2
+            exit 1
+            ;;
+        esac
+
     - name: Build and publish image
       uses: docker/build-push-action@v7
       with:
@@ -46,8 +125,9 @@ runs:
         push: true
         platforms: ${{ inputs.platforms }}
         build-args: |
+          BETTER_SQLITE3_VERSION=${{ steps.native-dependencies.outputs.better_sqlite3 }}
           BUILDER_PLATFORM=linux/amd64
-        cache-from: type=registry,ref=${{ inputs.cache-ref }}
-        cache-to: type=registry,ref=${{ inputs.cache-ref }},mode=max
+        cache-from: ${{ steps.cache.outputs.from }}
+        cache-to: ${{ steps.cache.outputs.to }}
         tags: ${{ inputs.tags }}
         labels: ${{ inputs.labels }}

--- a/.github/workflows/main-image.yml
+++ b/.github/workflows/main-image.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Publish image
         uses: ./.github/actions/publish-docker-image

--- a/.github/workflows/main-image.yml
+++ b/.github/workflows/main-image.yml
@@ -1,0 +1,33 @@
+name: Main container image
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  GHCR_IMAGE: ghcr.io/gabeduartem/blocky-ui
+
+concurrency:
+  group: main-container-image
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    name: Publish main image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Publish image
+        uses: ./.github/actions/publish-docker-image
+        with:
+          ghcr-token: ${{ secrets.GITHUB_TOKEN }}
+          cache-ref: ${{ env.GHCR_IMAGE }}:buildcache
+          cache-policy: shared
+          tags: ${{ env.GHCR_IMAGE }}:main

--- a/.github/workflows/pr-image.yml
+++ b/.github/workflows/pr-image.yml
@@ -66,6 +66,8 @@ jobs:
         with:
           ghcr-token: ${{ secrets.GITHUB_TOKEN }}
           cache-ref: ${{ env.GHCR_IMAGE }}:buildcache
+          cache-policy: scoped
+          cache-scope: pr-${{ github.event.pull_request.number }}
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -140,6 +142,8 @@ jobs:
         with:
           ghcr-token: ${{ secrets.GITHUB_TOKEN }}
           cache-ref: ${{ env.GHCR_IMAGE }}:buildcache
+          cache-policy: scoped
+          cache-scope: pr-${{ steps.pr.outputs.number }}
           context: pr
           platforms: ${{ inputs.platforms }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,7 @@ jobs:
         with:
           ghcr-token: ${{ secrets.GITHUB_TOKEN }}
           cache-ref: ${{ env.GHCR_IMAGE }}:buildcache
+          cache-policy: read-only
           tags: |
             ${{ env.GHCR_IMAGE }}:latest
             ${{ env.GHCR_IMAGE }}:${{ matrix.package.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,10 +16,18 @@ RUN bun run build
 # Build better-sqlite3 on the target platform; the Next.js build runs on amd64 and would otherwise trace the wrong native addon.
 FROM node:22-alpine AS native-sqlite
 WORKDIR /app
-RUN apk add --no-cache g++ make python3
-COPY package.json ./
-RUN sqlite_version="$(node -p 'require("./package.json").dependencies["better-sqlite3"]')" \
-  && npm_config_build_from_source=true npm install --omit=dev --package-lock=false "better-sqlite3@${sqlite_version}"
+ARG BETTER_SQLITE3_VERSION
+RUN test -n "${BETTER_SQLITE3_VERSION}" \
+  && apk add --no-cache --virtual .build-deps g++ make python3 \
+  && npm_config_build_from_source=true npm install \
+    --no-save \
+    --omit=dev \
+    --package-lock=false \
+    "better-sqlite3@${BETTER_SQLITE3_VERSION}" \
+  && mkdir /native \
+  && cp node_modules/better-sqlite3/build/Release/better_sqlite3.node /native/ \
+  && rm -rf node_modules /root/.cache /root/.npm \
+  && apk del .build-deps
 
 FROM node:22-alpine AS runner
 WORKDIR /app
@@ -34,7 +42,7 @@ COPY --from=builder /app/public ./public
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 COPY --from=native-sqlite --chown=nextjs:nodejs \
-  /app/node_modules/better-sqlite3/build/Release/better_sqlite3.node \
+  /native/better_sqlite3.node \
   ./node_modules/better-sqlite3/build/Release/better_sqlite3.node
 
 USER nextjs


### PR DESCRIPTION
## Summary
- Add shared, scoped, and read-only Docker BuildKit cache policies.
- Add a main-branch image workflow and optimize native `better-sqlite3` builds.
- Publish release images to Docker Hub and preserve deprecated `DATABASE_URL` compatibility with warnings.

## Testing
- Not run.