### PR TITLE
 Read overview statistics from the query log when configured

### DIFF
--- a/.changeset/olive-pillows-repeat.md
+++ b/.changeset/olive-pillows-repeat.md
@@ -1,0 +1,11 @@
+---
+"blocky-ui": patch
+---
+
+Fixes the Overview cards reporting only a fraction of DNS traffic when Blocky runs more than one instance.
+
+Blocky's `/api/stats` is per-instance and held in memory: each instance counts only the queries it answered itself, and the counters reset whenever that instance restarts. Behind a load balancer the Overview therefore showed roughly one instance's share of traffic, and dropped back towards zero after every restart or redeploy.
+
+When a query log is configured, BlockyUI now reads the Overview's total queries, blocked count, cache hit rate, and average response time from it. The query log already spans every instance and survives restarts, so the cards match the traffic Blocky actually served. Cache size and blocklist sizes continue to come from `/api/stats` — they describe current state rather than traffic, and are the same on every instance.
+
+Installations without a query log are unaffected and continue to use `/api/stats`.

--- a/src/server/api/routers/stats.test.ts
+++ b/src/server/api/routers/stats.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { StatsResult } from "~/server/logs/types";
+
+const mocks = vi.hoisted(() => ({
+  fetchBlockyStatistics: vi.fn(),
+  getStats24h: vi.fn(),
+}));
+
+vi.mock("~/env", () => ({
+  env: {
+    BLOCKY_API_URL: "http://localhost:4000",
+    BLOCKY_REQUEST_HEADERS: undefined,
+    DEMO_MODE: false,
+  },
+}));
+
+vi.mock("~/server/blocky/statistics", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("~/server/blocky/statistics")>()),
+  fetchBlockyStatistics: mocks.fetchBlockyStatistics,
+}));
+
+import { statsRouter } from "~/server/api/routers/stats";
+import type { BlockyStatistics } from "~/server/blocky/statistics";
+
+/** Blocky reports traffic of its own, so a fallback is always distinguishable. */
+const BLOCKY_STATISTICS: BlockyStatistics = {
+  summary: {
+    queries: 200,
+    blocked: 50,
+    dropped: 0,
+    errors: 0,
+    avgResponseMs: 10,
+    cacheHitRate: 0.75,
+  },
+  cache: { entries: 42 },
+  lists: { denylist: { ads: 1000 }, allowlist: { custom: 5 } },
+  topDomains: [],
+  topBlockedDomains: [],
+  topClients: [],
+};
+
+const LOG_STATS: StatsResult = {
+  totalQueries: 5000,
+  blocked: 500,
+  cached: 3000,
+  forwarded: 1500,
+  durationSum: 40000,
+};
+
+const EMPTY_LOG_STATS: StatsResult = {
+  totalQueries: 0,
+  blocked: 0,
+  cached: 0,
+  forwarded: 0,
+  durationSum: 0,
+};
+
+function createCaller(withLogProvider: boolean) {
+  return statsRouter.createCaller({
+    headers: new Headers(),
+    isDemoServiceAvailable: () => true,
+    logProvider: withLogProvider
+      ? ({ getStats24h: mocks.getStats24h } as never)
+      : undefined,
+  } as never);
+}
+
+describe("stats.snapshot", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.fetchBlockyStatistics.mockResolvedValue(BLOCKY_STATISTICS);
+  });
+
+  it("uses blocky's own statistics when no query log is configured", async () => {
+    const snapshot = await createCaller(false).snapshot();
+
+    expect(snapshot?.overview.totalQueries).toBe(200);
+    expect(mocks.getStats24h).not.toHaveBeenCalled();
+  });
+
+  it("prefers the query log for traffic counters, keeping blocky's state fields", async () => {
+    mocks.getStats24h.mockResolvedValue(LOG_STATS);
+
+    const snapshot = await createCaller(true).snapshot();
+
+    // Traffic comes from the query log, which spans every blocky instance.
+    expect(snapshot?.overview.totalQueries).toBe(5000);
+    expect(snapshot?.overview.blocked).toBe(500);
+    expect(snapshot?.overview.avgResponseMs).toBe(8); // 40000 / 5000
+    expect(snapshot?.overview.cacheHitRate).toBeCloseTo(66.67, 1); // 3000 / 4500
+
+    // Current blocky state is not in the query log, so it stays as reported.
+    expect(snapshot?.overview.cacheEntries).toBe(42);
+    expect(snapshot?.overview.listedDomains).toBe(1000);
+  });
+
+  it("falls back to blocky's statistics when the query log throws", async () => {
+    mocks.getStats24h.mockRejectedValue(new Error("query log unreachable"));
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {
+      // Intentionally silenced: the router logs the failure it recovers from.
+    });
+
+    const snapshot = await createCaller(true).snapshot();
+
+    expect(snapshot?.overview.totalQueries).toBe(200);
+    expect(consoleError).toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+
+  it("falls back to blocky's statistics when the query log reports nothing", async () => {
+    // Providers that catch internally report zeroes rather than throwing, which
+    // would otherwise blank the cards while blocky is still serving traffic.
+    mocks.getStats24h.mockResolvedValue(EMPTY_LOG_STATS);
+
+    const snapshot = await createCaller(true).snapshot();
+
+    expect(snapshot?.overview.totalQueries).toBe(200);
+    expect(snapshot?.overview.blocked).toBe(50);
+  });
+
+  it("still reports zero when blocky itself has served no queries", async () => {
+    mocks.fetchBlockyStatistics.mockResolvedValue({
+      ...BLOCKY_STATISTICS,
+      summary: { ...BLOCKY_STATISTICS.summary, queries: 0, blocked: 0 },
+    });
+    mocks.getStats24h.mockResolvedValue(EMPTY_LOG_STATS);
+
+    const snapshot = await createCaller(true).snapshot();
+
+    expect(snapshot?.overview.totalQueries).toBe(0);
+  });
+});

--- a/src/server/api/routers/stats.test.ts
+++ b/src/server/api/routers/stats.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { StatsResult } from "~/server/logs/types";
+import { type LogProvider, type StatsResult } from "~/server/logs/types";
 
 const mocks = vi.hoisted(() => ({
   fetchBlockyStatistics: vi.fn(),
@@ -20,7 +20,10 @@ vi.mock("~/server/blocky/statistics", async (importOriginal) => ({
 }));
 
 import { statsRouter } from "~/server/api/routers/stats";
-import type { BlockyStatistics } from "~/server/blocky/statistics";
+import { type createTRPCContext } from "~/server/api/trpc";
+import { type BlockyStatistics } from "~/server/blocky/statistics";
+
+type TRPCContext = Awaited<ReturnType<typeof createTRPCContext>>;
 
 /** Blocky reports traffic of its own, so a fallback is always distinguishable. */
 const BLOCKY_STATISTICS: BlockyStatistics = {
@@ -56,18 +59,26 @@ const EMPTY_LOG_STATS: StatsResult = {
 };
 
 function createCaller(withLogProvider: boolean) {
-  return statsRouter.createCaller({
+  // Only getStats24h is exercised here; the rest of the provider is never
+  // reached, so a partial fake keeps the fixture honest about what it stubs.
+  const logProvider: Pick<LogProvider, "getStats24h"> = {
+    getStats24h: mocks.getStats24h,
+  };
+
+  const ctx: TRPCContext = {
     headers: new Headers(),
     isDemoServiceAvailable: () => true,
-    logProvider: withLogProvider
-      ? ({ getStats24h: mocks.getStats24h } as never)
-      : undefined,
-  } as never);
+    logProvider: withLogProvider ? (logProvider as LogProvider) : undefined,
+  };
+
+  return statsRouter.createCaller(ctx);
 }
 
 describe("stats.snapshot", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    // resetAllMocks, not clearAllMocks: the former also drops mockResolvedValue
+    // implementations, so one test's stub cannot leak into the next.
+    vi.resetAllMocks();
     mocks.fetchBlockyStatistics.mockResolvedValue(BLOCKY_STATISTICS);
   });
 

--- a/src/server/api/routers/stats.ts
+++ b/src/server/api/routers/stats.ts
@@ -67,7 +67,24 @@ export const statsRouter = createTRPCRouter({
     // When a query log is configured it spans every instance and survives
     // restarts, so prefer it for the traffic counters. The remaining fields
     // (cache size, list sizes) are current blocky state and stay as reported.
-    const stats = await ctx.logProvider.getStats24h();
+    //
+    // The query log is a separate service and can be unreachable, so treat it
+    // as best-effort: if it fails, or reports no queries at all while blocky
+    // says it served some, keep blocky's numbers rather than blanking the
+    // cards. Providers signal failure inconsistently — some throw, others log
+    // and return zeroes — so guard against both.
+    let stats: StatsResult;
+    try {
+      stats = await ctx.logProvider.getStats24h();
+    } catch (error) {
+      console.error("Failed to read statistics from the query log:", error);
+      return snapshot;
+    }
+
+    if (stats.totalQueries === 0 && snapshot.overview.totalQueries > 0) {
+      return snapshot;
+    }
+
     return {
       ...snapshot,
       overview: { ...snapshot.overview, ...overviewFromLogs(stats) },

--- a/src/server/api/routers/stats.ts
+++ b/src/server/api/routers/stats.ts
@@ -5,6 +5,7 @@ import {
   createStatisticsSnapshot,
   fetchBlockyStatistics,
 } from "~/server/blocky/statistics";
+import type { StatsResult } from "~/server/logs/types";
 
 const timeRangeSchema = z.enum(TIME_RANGES);
 const topListTypeSchema = z.enum(["domains", "clients"]);
@@ -22,6 +23,29 @@ const searchSchema = z.object({
   limit: z.number().min(1).max(50).default(10),
 });
 
+/**
+ * Derives the overview's traffic counters from query-log totals.
+ *
+ * Mirrors blocky's own `curatedSummary()` (stats/collector.go): the cache hit
+ * rate is measured against lookups (cached + forwarded) rather than all
+ * queries, because a blocked or locally-answered query never consults the
+ * cache. Averaging duration here — instead of in each provider — keeps the
+ * result identical no matter which backend supplied the sums.
+ */
+function overviewFromLogs(stats: StatsResult) {
+  const { totalQueries, blocked, cached, forwarded, durationSum } = stats;
+  const lookups = cached + forwarded;
+
+  return {
+    totalQueries,
+    blocked,
+    blockedPercentage: totalQueries > 0 ? (blocked / totalQueries) * 100 : 0,
+    cacheHitRate: lookups > 0 ? (cached / lookups) * 100 : 0,
+    avgResponseMs:
+      totalQueries > 0 ? Math.trunc(durationSum / totalQueries) : 0,
+  };
+}
+
 export const statsRouter = createTRPCRouter({
   snapshot: publicProcedure.query(async ({ ctx }) => {
     if (!ctx.isDemoServiceAvailable("statistics")) {
@@ -32,7 +56,22 @@ export const statsRouter = createTRPCRouter({
     if (!statistics) {
       return null;
     }
-    return createStatisticsSnapshot(statistics);
+
+    const snapshot = createStatisticsSnapshot(statistics);
+    if (!ctx.logProvider) {
+      return snapshot;
+    }
+
+    // Blocky's /api/stats is per-instance and in-memory: it only counts the
+    // queries the responding instance served, and resets whenever it restarts.
+    // When a query log is configured it spans every instance and survives
+    // restarts, so prefer it for the traffic counters. The remaining fields
+    // (cache size, list sizes) are current blocky state and stay as reported.
+    const stats = await ctx.logProvider.getStats24h();
+    return {
+      ...snapshot,
+      overview: { ...snapshot.overview, ...overviewFromLogs(stats) },
+    };
   }),
 
   queriesOverTime: publicProcedure

--- a/src/server/logs/__tests__/provider-conformance.test.ts
+++ b/src/server/logs/__tests__/provider-conformance.test.ts
@@ -211,6 +211,25 @@ function defineProviderTests(providerName: string) {
         expect(result.totalQueries).toBe(expected.total);
         expect(result.blocked).toBe(expected.blocked);
       });
+
+      it("counts cached and forwarded lookups", async () => {
+        const expected = countEntriesInRange(seedData, "24h");
+        const result = await provider.getStats24h();
+
+        expect(result.cached).toBe(expected.cached);
+        expect(result.forwarded).toBe(expected.forwarded);
+
+        // The seed carries CONDITIONAL entries, so a provider that forwards on
+        // RESOLVED alone cannot pass this.
+        expect(expected.forwarded).toBeGreaterThan(0);
+        expect(expected.cached).toBeGreaterThan(0);
+      });
+
+      it("sums durations over the same entries it counts", async () => {
+        const expected = countEntriesInRange(seedData, "24h");
+        const result = await provider.getStats24h();
+        expect(result.durationSum).toBe(expected.durationSum);
+      });
     });
 
     describe("getQueriesOverTime", () => {
@@ -904,6 +923,9 @@ describe("cross-provider consistency", () => {
     compareAcrossProviders(results, (baseline, current) => {
       expect(current.totalQueries).toBe(baseline.totalQueries);
       expect(current.blocked).toBe(baseline.blocked);
+      expect(current.cached).toBe(baseline.cached);
+      expect(current.forwarded).toBe(baseline.forwarded);
+      expect(current.durationSum).toBe(baseline.durationSum);
     });
   });
 

--- a/src/server/logs/__tests__/seed-data.ts
+++ b/src/server/logs/__tests__/seed-data.ts
@@ -83,6 +83,28 @@ function createTemplates(): EntryTemplate[] {
       questionType: "A",
     },
     {
+      offsetMs: 16 * MINUTE,
+      clientIp: "192.168.1.10",
+      clientName: "laptop",
+      durationMs: 22,
+      reason: "CONDITIONAL",
+      questionName: "nas.lan",
+      answer: "192.168.1.5",
+      responseType: "CONDITIONAL",
+      questionType: "A",
+    },
+    {
+      offsetMs: 17 * MINUTE,
+      clientIp: "192.168.1.30",
+      clientName: "server-01",
+      durationMs: 2,
+      reason: "FILTERED",
+      questionName: "filtered-site.com",
+      answer: "",
+      responseType: "FILTERED",
+      questionType: "AAAA",
+    },
+    {
       offsetMs: 20 * MINUTE,
       clientIp: "192.168.1.10",
       clientName: "laptop",
@@ -571,25 +593,42 @@ export function createSeedData(): LogEntry[] {
 export function countEntriesInRange(
   entries: LogEntry[],
   range: TimeRange,
-): { total: number; blocked: number; cached: number } {
+): {
+  total: number;
+  blocked: number;
+  cached: number;
+  forwarded: number;
+  durationSum: number;
+} {
   const { startTime } = getTimeRangeConfig(range);
 
   let total = 0;
   let blocked = 0;
   let cached = 0;
+  let forwarded = 0;
+  let durationSum = 0;
 
+  // Spelled out rather than reusing the provider's own bucket constants, so
+  // the expectation stays an independent check on how they are categorised.
   for (const entry of entries) {
     const ts = entry.requestTs ? new Date(entry.requestTs).getTime() : 0;
     if (ts >= startTime.getTime()) {
       total++;
+      durationSum += entry.durationMs ?? 0;
       if (entry.responseType === "BLOCKED") {
         blocked++;
       }
       if (entry.responseType === "CACHED") {
         cached++;
       }
+      if (
+        entry.responseType === "RESOLVED" ||
+        entry.responseType === "CONDITIONAL"
+      ) {
+        forwarded++;
+      }
     }
   }
 
-  return { total, blocked, cached };
+  return { total, blocked, cached, forwarded, durationSum };
 }

--- a/src/server/logs/aggregation-utils.ts
+++ b/src/server/logs/aggregation-utils.ts
@@ -2,12 +2,30 @@ import { type TimeRange } from "~/lib/constants";
 import type {
   LogEntry,
   QueriesOverTimeEntry,
+  StatsResult,
   TopDomainEntry,
   TopClientEntry,
   QueryTypeEntry,
   SearchDomainEntry,
   SearchClientEntry,
 } from "./types";
+
+/**
+ * Response types that count as a cache hit or a forwarded lookup.
+ *
+ * These mirror blocky's own `categorize()` (stats/collector.go), which decides
+ * how `/api/stats` buckets each response type. The cache hit rate is measured
+ * against these two buckets, so keeping them aligned means a log-derived
+ * overview reports the same rate blocky would.
+ *
+ * Note: blocky also folds FILTERED and NOTFQDN into "blocked", whereas this
+ * codebase counts only BLOCKED throughout (query log filters, top domains,
+ * queries-over-time). That difference is left alone here so "blocked" keeps one
+ * meaning across the UI.
+ */
+export const CACHED_RESPONSE_TYPES = ["CACHED"];
+export const FORWARDED_RESPONSE_TYPES = ["RESOLVED", "CONDITIONAL"];
+export const BLOCKED_RESPONSE_TYPES = ["BLOCKED"];
 
 export interface TimeRangeConfig {
   startTime: Date;
@@ -43,6 +61,39 @@ export function getTimeRangeConfig(range: TimeRange): TimeRangeConfig {
         bucketCount: 30,
       };
   }
+}
+
+/**
+ * Counts the last 24 hours of entries into blocky's outcome buckets.
+ *
+ * Returns `durationSum` rather than an average: summing integers is exact and
+ * therefore identical across every provider, whereas each backend's own AVG()
+ * rounds differently. Callers divide once, at the point of display.
+ */
+export function aggregateStats24h(entries: LogEntry[]): StatsResult {
+  const { startTime } = getTimeRangeConfig("24h");
+  const stats: StatsResult = {
+    totalQueries: 0,
+    blocked: 0,
+    cached: 0,
+    forwarded: 0,
+    durationSum: 0,
+  };
+
+  for (const entry of entries) {
+    const ts = entry.requestTs ? new Date(entry.requestTs).getTime() : 0;
+    if (ts < startTime.getTime()) continue;
+
+    stats.totalQueries++;
+    stats.durationSum += entry.durationMs ?? 0;
+
+    const rtype = entry.responseType ?? "";
+    if (CACHED_RESPONSE_TYPES.includes(rtype)) stats.cached++;
+    if (FORWARDED_RESPONSE_TYPES.includes(rtype)) stats.forwarded++;
+    if (BLOCKED_RESPONSE_TYPES.includes(rtype)) stats.blocked++;
+  }
+
+  return stats;
 }
 
 export function aggregateQueriesOverTime(

--- a/src/server/logs/csv/client-provider.ts
+++ b/src/server/logs/csv/client-provider.ts
@@ -14,6 +14,7 @@ import {
   createFilterFn,
   createTimeFilter,
   computeStats,
+  EMPTY_STATS,
 } from "./utils";
 
 const DATE_PATTERN = /^(\d{4}-\d{2}-\d{2})_.+\.log$/;
@@ -127,7 +128,7 @@ export class CsvClientLogProvider extends BaseMemoryLogProvider {
   async getStats24h(): Promise<StatsResult> {
     const logFiles = await this.findLatestDateFiles();
     if (logFiles.length === 0) {
-      return { totalQueries: 0, blocked: 0 };
+      return EMPTY_STATS;
     }
 
     try {
@@ -139,7 +140,7 @@ export class CsvClientLogProvider extends BaseMemoryLogProvider {
       return computeStats(entriesArrays.flat());
     } catch (error) {
       console.error("Error getting stats:", error);
-      return { totalQueries: 0, blocked: 0 };
+      return EMPTY_STATS;
     }
   }
 

--- a/src/server/logs/csv/provider.ts
+++ b/src/server/logs/csv/provider.ts
@@ -14,6 +14,7 @@ import {
   createFilterFn,
   createTimeFilter,
   computeStats,
+  EMPTY_STATS,
 } from "./utils";
 
 /**
@@ -104,7 +105,7 @@ export class CsvLogProvider extends BaseMemoryLogProvider {
   async getStats24h(): Promise<StatsResult> {
     const logFile = await this.findLatestLogFile();
     if (!logFile) {
-      return { totalQueries: 0, blocked: 0 };
+      return EMPTY_STATS;
     }
 
     try {
@@ -116,7 +117,7 @@ export class CsvLogProvider extends BaseMemoryLogProvider {
       return computeStats(entries);
     } catch (error) {
       console.error("Error getting stats:", error);
-      return { totalQueries: 0, blocked: 0 };
+      return EMPTY_STATS;
     }
   }
 

--- a/src/server/logs/csv/utils.ts
+++ b/src/server/logs/csv/utils.ts
@@ -1,6 +1,7 @@
 import * as fs from "fs";
 import * as readline from "readline";
-import type { LogEntry, QueryLogsOptions } from "../types";
+import { aggregateStats24h } from "../aggregation-utils";
+import type { LogEntry, QueryLogsOptions, StatsResult } from "../types";
 
 function parseLogLine(line: string): LogEntry | null {
   try {
@@ -118,10 +119,14 @@ export function createTimeFilter(since: Date): (entry: LogEntry) => boolean {
   };
 }
 
-export function computeStats(entries: LogEntry[]): {
-  totalQueries: number;
-  blocked: number;
-} {
-  const blocked = entries.filter((e) => e.responseType === "BLOCKED").length;
-  return { totalQueries: entries.length, blocked };
+export const EMPTY_STATS: StatsResult = {
+  totalQueries: 0,
+  blocked: 0,
+  cached: 0,
+  forwarded: 0,
+  durationSum: 0,
+};
+
+export function computeStats(entries: LogEntry[]): StatsResult {
+  return aggregateStats24h(entries);
 }

--- a/src/server/logs/demo-provider.ts
+++ b/src/server/logs/demo-provider.ts
@@ -5,7 +5,7 @@ import type {
   QueryLogsOptions,
   QueryLogsResult,
 } from "./types";
-import { getTimeRangeConfig } from "./aggregation-utils";
+import { aggregateStats24h, getTimeRangeConfig } from "./aggregation-utils";
 import { BaseMemoryLogProvider } from "./base-provider";
 
 /**
@@ -64,21 +64,7 @@ export class DemoLogProvider extends BaseMemoryLogProvider {
 
   async getStats24h(): Promise<StatsResult> {
     const { logEntryMock } = await import("~/mocks/logEntryMock");
-    const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
-
-    const recentLogs = logEntryMock.filter((log) => {
-      const logDate = new Date(log.requestTs ?? 0);
-      return logDate >= oneDayAgo;
-    });
-
-    const blocked = recentLogs.filter(
-      (log) => log.responseType === "BLOCKED",
-    ).length;
-
-    return {
-      totalQueries: recentLogs.length,
-      blocked,
-    };
+    return aggregateStats24h(logEntryMock);
   }
 
   protected async fetchEntriesInRange(range: TimeRange): Promise<LogEntry[]> {

--- a/src/server/logs/sql/base-provider.ts
+++ b/src/server/logs/sql/base-provider.ts
@@ -12,11 +12,17 @@ import {
   and,
   eq,
   gte,
+  inArray,
   type SQL,
   type Column,
 } from "drizzle-orm";
 import { type TimeRange } from "~/lib/constants";
-import { getTimeRangeConfig } from "~/server/logs/aggregation-utils";
+import {
+  BLOCKED_RESPONSE_TYPES,
+  CACHED_RESPONSE_TYPES,
+  FORWARDED_RESPONSE_TYPES,
+  getTimeRangeConfig,
+} from "~/server/logs/aggregation-utils";
 import type {
   LogProvider,
   LogEntry,
@@ -284,10 +290,16 @@ export abstract class BaseSqlLogProvider implements LogProvider {
   async getStats24h(): Promise<StatsResult> {
     const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
 
+    const countWhereTypeIn = (types: string[]) =>
+      sql<number>`sum(case when ${inArray(this.columns.responseType, types)} then 1 else 0 end)`;
+
     const result = await this.db
       .select({
         totalQueries: sql<number>`count(*)`,
-        blocked: sql<number>`sum(case when ${this.columns.responseType} = 'BLOCKED' then 1 else 0 end)`,
+        blocked: countWhereTypeIn(BLOCKED_RESPONSE_TYPES),
+        cached: countWhereTypeIn(CACHED_RESPONSE_TYPES),
+        forwarded: countWhereTypeIn(FORWARDED_RESPONSE_TYPES),
+        durationSum: sql<number>`sum(coalesce(${this.columns.durationMs}, 0))`,
       })
       .from(this.table)
       .where(
@@ -297,6 +309,9 @@ export abstract class BaseSqlLogProvider implements LogProvider {
     return {
       totalQueries: Number(result[0]?.totalQueries ?? 0),
       blocked: Number(result[0]?.blocked ?? 0),
+      cached: Number(result[0]?.cached ?? 0),
+      forwarded: Number(result[0]?.forwarded ?? 0),
+      durationSum: Number(result[0]?.durationSum ?? 0),
     };
   }
 

--- a/src/server/logs/types.ts
+++ b/src/server/logs/types.ts
@@ -20,6 +20,10 @@ export interface LogEntry {
 export interface StatsResult {
   totalQueries: number;
   blocked: number;
+  cached: number;
+  forwarded: number;
+  /** Summed, not averaged: integers compare exactly across every provider. */
+  durationSum: number;
 }
 
 export interface QueriesOverTimeEntry {

--- a/src/server/logs/victorialogs/provider.ts
+++ b/src/server/logs/victorialogs/provider.ts
@@ -1,5 +1,10 @@
 import ky from "ky";
-import { getTimeRangeConfig } from "~/server/logs/aggregation-utils";
+import {
+  BLOCKED_RESPONSE_TYPES,
+  CACHED_RESPONSE_TYPES,
+  FORWARDED_RESPONSE_TYPES,
+  getTimeRangeConfig,
+} from "~/server/logs/aggregation-utils";
 import {
   type LogEntry,
   type LogProvider,
@@ -171,21 +176,25 @@ export class VictoriaLogsProvider implements LogProvider {
   }
 
   async getStats24h(): Promise<StatsResult> {
-    // VictoriaLogs does not support conditional aggregation (count(if(...))),
-    // so total and blocked counts require separate queries.
-    const [totalResult, blockedResult] = await Promise.all([
-      this.queryRaw(`${BASE_FILTER} | stats count() as total`, {
-        start: "24h",
-      }),
-      this.queryRaw(
-        `${BASE_FILTER} AND response_type:BLOCKED | stats count() as blocked`,
-        { start: "24h" },
-      ),
-    ]);
+    const anyOf = (field: string, values: string[]) =>
+      values.map((value) => `${field}:${value}`).join(" or ");
+
+    const [result] = await this.queryRaw(
+      `${BASE_FILTER} | stats
+         count() as total,
+         count() if (${anyOf("response_type", CACHED_RESPONSE_TYPES)}) as cached,
+         count() if (${anyOf("response_type", FORWARDED_RESPONSE_TYPES)}) as forwarded,
+         count() if (${anyOf("response_type", BLOCKED_RESPONSE_TYPES)}) as blocked,
+         sum(duration_ms) as duration_sum`,
+      { start: "24h" },
+    );
 
     return {
-      totalQueries: Number(totalResult[0]?.total ?? 0),
-      blocked: Number(blockedResult[0]?.blocked ?? 0),
+      totalQueries: Number(result?.total ?? 0),
+      blocked: Number(result?.blocked ?? 0),
+      cached: Number(result?.cached ?? 0),
+      forwarded: Number(result?.forwarded ?? 0),
+      durationSum: Number(result?.duration_sum ?? 0),
     };
   }
 


### PR DESCRIPTION
## Before Submitting This PR

**Please confirm you have done the following:**

- [x] I have searched [existing issues](https://github.com/GabeDuarteM/blocky-ui/issues) and [pull requests](https://github.com/GabeDuarteM/blocky-ui/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/GabeDuarteM/blocky-ui/blob/main/CONTRIBUTING.md)

**If this is a feature or change that was previously closed/rejected:**

~- [ ] I have explained in the description below why this should be reconsidered~
N/A

## Human Written Description

<!-- Describe your changes clearly and concisely

Please write 2-3 sentences in your own words explaining:
- What problem you noticed or idea you had
- Why you think this change matters

This section should be YOUR thinking, not AI-generated text. Even if AI helped write the code, we want to hear from you directly. Your perspective as a human is what makes contributions meaningful. Your PR may be rejected if you do not
include a human-written description.
-->

#390 moved the Overview cards from Prometheus to Blocky's new `/api/stats` (v0.33.0). That endpoint is backed by an in-memory, per-pod/container collector. Blocky's only cross-instance mechanism is Redis, but that is optional so even an upstream Blocky fix wouldn't help deployments that don't run Redis.

When a log provider is configured, blocky-ui already has a cluster-wide, longterm record of every query. It just doesn't use it for the Overview, while it does for every other panel.

I believe that this impacts anyone who runs Blocky with more than one replica. Requests land on whichever pod the load balancer picks and that pod only counts the queries it served itself. And because the counters live in memory, they reset to zero on every restart, redeploy, or image bump.

The goal for this PR is to make snapshot prefer `ctx.logProvider` when a query log is configured, the same way `topList` and `queriesOverTime` already do. Only the traffic counters move (total, blocked, cache hit rate, avg response). Installations with no query log should not be affected.

## Related Issues/Discussions

<!-- Link to related issues, discussions, or previous PRs -->
<!-- If reopening something previously closed, explain why this should be reconsidered -->
<!-- Fixes # -->
<!-- Discussed in: -->
Related to PR: #390 

## Testing

<!-- Describe how you tested your changes and if you need help getting additional testing -->
### Reproducing the problem

Blocky runs with 3 replicas behind a single Service. Hitting `/api/stats` 20 times, same URL:

```bash
for i in $(seq 1 20); do
  curl -s http://<blocky-host>/api/stats | jq -r '.summary.queries'
done | sort -n | uniq -c

#   8 3518    <- one instance's in-memory counter
#   5 3706    <- another's
#   7 3793    <- another's
```

Three different answers to identical consecutive requests, because the load balancer picks a different instance each time and each one only counted the queries it served itself. Querying the pods directly returns exactly those three numbers. The Overview flickers between them on every refresh.

### Verifying the fix

Built image running against the same cluster (3 replicas, query log in VictoriaLogs), Overview compared against two independent sources:

(At the time of the comparison)
| | Total queries (24h) | Cache hit rate |
|---|---|---|
| Overview, before | 660 | ~22% |
| Overview, after | **36,523** | **51.3%** |
| VictoriaLogs, queried directly | 36,523 | 51.3% |
| Prometheus (`blocky_query_total`, all 3 pods) | 36,398 | — |

Repeated calls now return the same answer regardless of which instance serves them, and the numbers survive a pod restart.

### Test suite

`bun run test` — **433 passing** (baseline on `main` is 421; 12 new, none modified to accommodate the change).

The conformance suite runs every provider against testcontainer-backed MySQL, PostgreSQL, SQLite, CSV, CSV-client and VictoriaLogs. I extended it rather than relaxed it:

- `getStats24h` now also asserts `cached`, `forwarded` and `durationSum`.
- The cross-provider identity test (`getStats24h returns identical results across all providers`) asserts the new fields match across all six backends.
- Added `CONDITIONAL` and `FILTERED` entries to the seed data, so the response-type buckets are actually exercised. A provider that forwards on `RESOLVED` alone now fails.

`bun run verify` — lint, format, typecheck, knip and jscpd all pass.


## Screenshots/Videos (if applicable)

<!-- Add screenshots or videos demonstrating the changes in action. If possible/necessary, please also include a before/after. -->

In the screenshots below you can see the discrepancy between the overview panels on top showing ~600 queries in the past 24 hours (pulling from one of the pods `/api/stats`) where the "Top Domains" for the same time period is pulling from the log provider with many more hits for just one of the domains.

### Before:
<img width="2566" height="4980" alt="previous" src="https://github.com/user-attachments/assets/3fed2abd-c374-4d08-a7d4-1a3ff7cd4e5e" />


### After: 
<img width="2566" height="4980" alt="fixed" src="https://github.com/user-attachments/assets/9b874383-7391-413b-9b41-3aaf63bcf2f9" />


## AI Assistance

<!-- AI-assisted PRs are welcomed if properly reviewed and tested beforehand. Just let us know so we can review it appropriately as well (and please, be honest about it). -->

- [x] AI was used in this PR (please describe below)

**If AI was used:**

- Tools used: Claude Code - Sonnet 5
- How extensively: Debugging the issue at hand, reviewing upstream Blocky and the changes made with PR #390. Brainstorming potential solutions, implementing a fix, and then running an image with the fix in the cluster for validations.
