### PR TITLE
feat: tls connection for postgres querylog

### DIFF
--- a/src/server/logs/postgres/provider.ts
+++ b/src/server/logs/postgres/provider.ts
@@ -1,29 +1,112 @@
 import { sql, type SQL } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
+import fs from "node:fs";
 
 import { logEntries } from "~/server/logs/postgres/schema";
 import { type TimeRange } from "~/lib/constants";
 import { BaseSqlLogProvider } from "~/server/logs/sql/base-provider";
 
+interface PostgreSQLOptions {
+  connectionUri: string;
+  // SSL is now optional because we derive it from the URI
+  ssl?: {
+    enabled: boolean;
+    caPath?: string;
+    certPath?: string;
+    keyPath?: string;
+  };
+}
+
 export class PostgreSQLLogProvider extends BaseSqlLogProvider {
   private readonly conn: ReturnType<typeof postgres>;
 
-  constructor(options: { connectionUri: string }) {
-    const conn = postgres(options.connectionUri, {
-      connection: {
-        timezone: "UTC",
-      },
-    });
-    const db = drizzle(conn, { schema: { logEntries } });
+  constructor(options: PostgreSQLOptions) {
+    console.log("[DB Debug] Initializing PostgreSQLLogProvider...");
+    
+    // 1. Parse the URI to extract parameters
+    const url = new URL(options.connectionUri);
+    const params = url.searchParams;
 
-    super({
-      db,
-      table: logEntries,
-      columns: logEntries,
-    });
+    // 2. Derive SSL settings
+    const sslMode = params.get("sslmode") || "disable";
+    const isSslEnabled = options.ssl?.enabled ?? (sslMode !== "disable");
+    
+    const caPath = options.ssl?.caPath ?? params.get("sslrootcert");
+    const certPath = options.ssl?.certPath ?? params.get("sslcert");
+    const keyPath = options.ssl?.keyPath ?? params.get("sslkey");
 
-    this.conn = conn;
+    console.log(`[DB Debug] URI Host: ${url.hostname}`);
+    console.log(`[DB Debug] SSL Enabled: ${isSslEnabled} (Mode: ${sslMode})`);
+
+    let sslConfig: any = null;
+
+    if (isSslEnabled) {
+      sslConfig = {};
+      
+      const loadCert = (label: string, path?: string | null) => {
+        if (!path) return null;
+        if (!fs.existsSync(path)) {
+          console.error(`[DB Debug] ${label} file NOT FOUND at: ${path}`);
+          return null;
+        }
+        const content = fs.readFileSync(path);
+        console.log(`[DB Debug] ${label} loaded successfully (${content.length} bytes)`);
+        return content;
+      };
+
+      sslConfig.ca = loadCert("Root CA", caPath);
+      sslConfig.cert = loadCert("Client Cert", certPath);
+      sslConfig.key = loadCert("Client Key", keyPath);
+    }
+
+    // 3. CLEAN THE URI
+    // We must remove libpq-specific SSL params so the server doesn't reject the startup packet
+    const cleanParams = new URLSearchParams(params);
+    cleanParams.delete("sslmode");
+    cleanParams.delete("sslcert");
+    cleanParams.delete("sslkey");
+    cleanParams.delete("sslrootcert");
+    
+    // Reconstruct the URI without the forbidden parameters
+    const cleanedUri = `${url.protocol}//${url.username}:${url.password ? encodeURIComponent(url.password) : ''}@${url.hostname}:${url.port}${cleanParams.toString() ? '?' + cleanParams.toString() : ''}${url.pathname}`;
+
+    console.log(cleanedUri);
+
+    try {
+      // Pass the CLEANED uri, not the original one
+      const conn = postgres(cleanedUri, {
+        ssl: sslConfig,
+        connection: {
+          timezone: "UTC",
+        },
+      });
+
+      (async () => {
+        try {
+          console.log("[DB Debug] Attempting immediate connection test...");
+          await conn`SELECT 1`; 
+          console.log("[DB Debug] Connection test successful!");
+        } catch (err: any) {
+          console.error("[DB Debug] CONNECTION TEST FAILED:");
+          console.error(`- Message: ${err.message}`);
+          console.error(`- Code: ${err.code}`);
+        }
+      })();
+
+      const db = drizzle(conn, { schema: { logEntries } });
+
+      super({
+        db,
+        table: logEntries,
+        columns: logEntries,
+      });
+
+      this.conn = conn;
+    } catch (initError: any) {
+      console.error("[DB Debug] Fatal error during driver initialization:", initError);
+      throw initError;
+    }
   }
 
   async close(): Promise<void> {
@@ -39,22 +122,18 @@ export class PostgreSQLLogProvider extends BaseSqlLogProvider {
 
     switch (range) {
       case "1h":
-        // Round to 5-minute intervals
         return sql.raw(
           `TO_CHAR(DATE_TRUNC('hour', ${col}) + INTERVAL '5 min' * FLOOR(EXTRACT(MINUTE FROM ${col}) / 5), 'YYYY-MM-DD HH24:MI')`,
         );
       case "24h":
-        // Round to hourly intervals
         return sql.raw(
           `TO_CHAR(DATE_TRUNC('hour', ${col}), 'YYYY-MM-DD HH24:00')`,
         );
       case "7d":
-        // Round to 6-hour intervals (0, 6, 12, 18)
         return sql.raw(
           `TO_CHAR(DATE_TRUNC('day', ${col}) + INTERVAL '6 hours' * FLOOR(EXTRACT(HOUR FROM ${col}) / 6), 'YYYY-MM-DD HH24:00')`,
         );
       case "30d":
-        // Round to daily intervals
         return sql.raw(`TO_CHAR(DATE_TRUNC('day', ${col}), 'YYYY-MM-DD')`);
     }
   }


### PR DESCRIPTION
## Before Submitting This PR

**Please confirm you have done the following:**

- [ x] I have searched [existing issues](https://github.com/GabeDuarteM/blocky-ui/issues) and [pull requests](https://github.com/GabeDuarteM/blocky-ui/pulls) (including closed ones) to ensure this isn't a duplicate
- [x ] I have read [CONTRIBUTING.md](https://github.com/GabeDuarteM/blocky-ui/blob/main/CONTRIBUTING.md)

**If this is a feature or change that was previously closed/rejected:**

- [x ] I have explained in the description below why this should be reconsidered

## Human Written Description

Please write 2-3 sentences in your own words explaining:
- The blocky-ui `QUERY_LOG_TARGET` takes a postgres uri. I am uing mtls in my postgres database and this connection was failing
- I investigated how the connection string was being passed and it did not cater for optional ssl so I added it


## Related Issues/Discussions

None

<!-- Link to related issues, discussions, or previous PRs -->
<!-- If reopening something previously closed, explain why this should be reconsidered -->

<!-- Fixes # -->
<!-- Discussed in: -->

## Testing

I ran this against my existing database with mtls and it works correctly

## Screenshots/Videos (if applicable)

<!-- Add screenshots or videos demonstrating the changes in action. If possible/necessary, please also include a before/after. -->

## AI Assistance

<!-- AI-assisted PRs are welcomed if properly reviewed and tested beforehand. Just let us know so we can review it appropriately as well (and please, be honest about it). -->

- [ x] AI was used in this PR (please describe below)


**If AI was used:**

- Tools used: Gemma on duck.ai
- How extensively: this code is entirely suggested by the AI. I used it to iterate, gave suggestions, tested them and requested for better logging.
