### PR TITLE
Feat/hide local discovery domains

### DIFF
--- a/.changeset/hide-local-discovery-domains.md
+++ b/.changeset/hide-local-discovery-domains.md
@@ -1,0 +1,7 @@
+---
+"blocky-ui": minor
+---
+
+Add an optional switch to hide local service-discovery and special-use domains from Query Logs and Top Domains.
+
+Set `HIDE_LOCAL_DISCOVERY_DOMAINS=true` to offer the switch, which is on by default and can be turned off to query those names again. It matches `.arpa`, `.localhost`, `.localdomain` and DNS-SD names containing `._tcp.` or `._udp.`. Summary counts are never filtered.

--- a/.env.example
+++ b/.env.example
@@ -55,3 +55,12 @@ DEMO_MODE=false
 # QUERY_LOG_TYPE=console
 # QUERY_LOG_CONSOLE_PROVIDER=victorialogs
 # QUERY_LOG_TARGET="http://victoria-logs-host:9428"
+
+# Offer a switch to hide local service-discovery and special-use domains
+# (.arpa, .localhost, .localdomain, and DNS-SD names containing ._tcp. / ._udp.).
+# On a home network these dominate the lists without saying anything useful.
+#
+# Setting this adds a switch to Query Logs and Top Domains, on by default. Turning
+# the switch off puts those names back into the query, so they can still be read.
+# Summary counts are never filtered.
+# HIDE_LOCAL_DISCOVERY_DOMAINS=true

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ BlockyUI is configured via environment variables in all deployment methods.
 | `QUERY_LOG_CONSOLE_PROVIDER` | Conditional | None                    | Required when `QUERY_LOG_TYPE=console`. Selects the console log backend. Currently supports `victorialogs`.              |
 | `QUERY_LOG_TARGET`           | No          | None                    | Connection string, SQLite file path, or log folder path for the same target as Blocky's `queryLog.target`.               |
 | `INSTANCE_NAME`              | No          | None                    | Custom label shown in the browser tab title. Useful for identifying multiple instances.                                  |
+| `HIDE_LOCAL_DISCOVERY_DOMAINS` | No | `false` | Offers a switch on Query Logs and Top Domains to hide `.arpa`, `.localhost`, `.localdomain` and DNS-SD (`._tcp.`/`._udp.`) names. The switch is on by default; turning it off queries those names again. Summary counts are never filtered. |
 | `DEMO_MODE`                  | No          | `false`                 | Enables a kiosk mode with mocked data and actions. Useful if you just want to see how it looks.                          |
 
 ### Common Setups

--- a/src/components/dashboard/query-logs/query-logs.tsx
+++ b/src/components/dashboard/query-logs/query-logs.tsx
@@ -47,6 +47,14 @@ export function QueryLogs() {
   const [questionTypeFilter, setQuestionTypeFilter] = useState("ALL");
   const [pageSize, setPageSize] = useState(10);
   const [autoRefresh, setAutoRefresh] = useState(true);
+  // Defaults to hiding: the noise is why the option exists. Operators who want
+  // the local-discovery traffic can switch it off and it is queried again.
+  const [hideLocalDiscovery, setHideLocalDiscovery] = useState(true);
+  const { data: features, isPending: featuresPending } =
+    api.blocky.features.useQuery(undefined, { retry: false });
+  // On error the query settles with no data, so treat it as "feature off" rather
+  // than leaving the log query disabled forever.
+  const featuresSettled = !featuresPending;
 
   const handleFilterChange = (value: QueryLogFilter) => {
     setFilter(value);
@@ -72,6 +80,9 @@ export function QueryLogs() {
     ? questionTypeFilter
     : undefined;
   const searchParams = {
+    hideLocalDiscovery: features?.localDiscoveryFilter
+      ? hideLocalDiscovery
+      : undefined,
     search,
     client,
     limit: pageSize,
@@ -88,6 +99,9 @@ export function QueryLogs() {
     refetch,
     error,
   } = api.blocky.getQueryLogs.useQuery(searchParams, {
+    // Without this the first render queries unfiltered, then refetches once the
+    // feature flag arrives -- a visible flash of the rows the switch exists to hide.
+    enabled: featuresSettled,
     placeholderData: (previousData) => {
       if (previousData === undefined) {
         return undefined;
@@ -136,6 +150,7 @@ export function QueryLogs() {
         offset: targetPage * pageSize,
         responseType,
         questionType,
+        hideLocalDiscovery: searchParams.hideLocalDiscovery,
       });
     },
   });
@@ -154,6 +169,36 @@ export function QueryLogs() {
             </CardDescription>
           </div>
           <div className="flex h-full items-center justify-center gap-4 pl-4">
+            {features?.localDiscoveryFilter ? (
+              <div className="flex items-center gap-2">
+                <Label
+                  htmlFor="hide-local-discovery"
+                  className="text-muted-foreground text-sm"
+                >
+                  Hide local
+                </Label>
+                <Tooltip disableHoverableContent>
+                  <TooltipTrigger asChild>
+                    <span className="inline-flex">
+                      <Switch
+                        id="hide-local-discovery"
+                        checked={hideLocalDiscovery}
+                        onCheckedChange={(next) => {
+                          setHideLocalDiscovery(next);
+                          // The filtered set is smaller; the current offset may be
+                          // past its end, which would show an empty page.
+                          setPageIndex(0);
+                        }}
+                      />
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent sideOffset={4}>
+                    Hide local service-discovery and special-use names (.arpa,
+                    .localhost, .localdomain, DNS-SD)
+                  </TooltipContent>
+                </Tooltip>
+              </div>
+            ) : null}
             <div className="flex items-center gap-2">
               <Label
                 htmlFor="auto-refresh"

--- a/src/components/dashboard/statistics/paginated-top-list.tsx
+++ b/src/components/dashboard/statistics/paginated-top-list.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ChevronLeft, ChevronRight, type LucideIcon } from "lucide-react";
+import { type ReactNode } from "react";
 
 import { Button } from "~/components/ui/button";
 import { CardFooter } from "~/components/ui/card";
@@ -24,6 +25,7 @@ interface PaginatedTopListProps {
   isLoading: boolean;
   filter: TopListFilter;
   onFilterChange: (filter: TopListFilter) => void;
+  headerExtra?: ReactNode;
   page: number;
   limit: number;
   onPageChange: (page: number) => void;
@@ -179,6 +181,7 @@ export function PaginatedTopList({
   isLoading,
   filter,
   onFilterChange,
+  headerExtra,
   page,
   limit,
   onPageChange,
@@ -191,6 +194,7 @@ export function PaginatedTopList({
       description={description}
       icon={icon}
       filterControls={{ value: filter, onChange: onFilterChange }}
+      headerExtra={headerExtra}
       isLoading={isLoading}
       isEmpty={items.length === 0}
       skeletonRows={limit}

--- a/src/components/dashboard/statistics/top-list-table.tsx
+++ b/src/components/dashboard/statistics/top-list-table.tsx
@@ -3,6 +3,12 @@
 import { useState } from "react";
 import { Globe, Users, type LucideIcon } from "lucide-react";
 
+import { Switch } from "~/components/ui/switch";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "~/components/ui/tooltip";
 import { usePrefetchAdjacentPages } from "~/hooks/use-prefetch-adjacent-pages";
 import { type TimeRange } from "~/lib/constants";
 import { api } from "~/trpc/react";
@@ -43,9 +49,32 @@ export function TopListTable({
   onPageChange,
 }: TopListTableProps) {
   const [filter, setFilter] = useState<TopListFilter>("all");
+  // Defaults to hiding. Applies to both the all and blocked views, because it is
+  // the same query with a different filter.
+  const [hideLocalDiscovery, setHideLocalDiscovery] = useState(true);
+  const { data: features, isPending: featuresPending } =
+    api.blocky.features.useQuery(undefined, { retry: false });
+  const showLocalDiscoveryToggle =
+    type === "domains" && Boolean(features?.localDiscoveryFilter);
+  const localDiscoveryInput = showLocalDiscoveryToggle
+    ? hideLocalDiscovery
+    : undefined;
+
   const query = api.stats.topList.useQuery(
-    { type, range, limit, offset: page * limit, filter },
-    { placeholderData: (previous) => previous },
+    {
+      type,
+      range,
+      limit,
+      offset: page * limit,
+      filter,
+      hideLocalDiscovery: localDiscoveryInput,
+    },
+    {
+      // Without this the first render queries unfiltered, then refetches once the
+      // feature flag arrives -- a visible flash of the rows the switch hides.
+      enabled: !featuresPending,
+      placeholderData: (previous) => previous,
+    },
   );
   const utils = api.useUtils();
   const totalPages = Math.ceil((query.data?.totalCount ?? 0) / limit);
@@ -62,6 +91,7 @@ export function TopListTable({
         limit,
         offset: targetPage * limit,
         filter,
+        hideLocalDiscovery: localDiscoveryInput,
       });
     },
   });
@@ -81,6 +111,31 @@ export function TopListTable({
       isLoading={query.isLoading || query.isPlaceholderData}
       filter={filter}
       onFilterChange={handleFilterChange}
+      headerExtra={
+        showLocalDiscoveryToggle ? (
+          <Tooltip disableHoverableContent>
+            {/* The trigger is the Switch itself, not a wrapper. A span is not
+                focusable, so the tooltip would never open from the keyboard --
+                and this control has no visible label, so the tooltip is the only
+                description of what it does. */}
+            <TooltipTrigger asChild>
+              <Switch
+                id="top-domains-hide-local-discovery"
+                aria-label="Hide local service-discovery domains"
+                checked={hideLocalDiscovery}
+                onCheckedChange={(next) => {
+                  setHideLocalDiscovery(next);
+                  onPageChange(0);
+                }}
+              />
+            </TooltipTrigger>
+            <TooltipContent sideOffset={4}>
+              Hide local service-discovery and special-use names (.arpa,
+              .localhost, .localdomain, DNS-SD)
+            </TooltipContent>
+          </Tooltip>
+        ) : null
+      }
       page={page}
       limit={limit}
       onPageChange={onPageChange}

--- a/src/components/dashboard/statistics/top-list-table.tsx
+++ b/src/components/dashboard/statistics/top-list-table.tsx
@@ -114,20 +114,24 @@ export function TopListTable({
       headerExtra={
         showLocalDiscoveryToggle ? (
           <Tooltip disableHoverableContent>
-            {/* The trigger is the Switch itself, not a wrapper. A span is not
-                focusable, so the tooltip would never open from the keyboard --
-                and this control has no visible label, so the tooltip is the only
-                description of what it does. */}
+            {/* The span is load-bearing. Radix Tooltip sets data-state on its
+                trigger, and Switch styles itself from data-state=checked /
+                unchecked -- making the Switch the trigger directly leaves it
+                with neither, so it renders with no background and no thumb
+                movement. Screen readers get the aria-label; the tooltip is a
+                pointer affordance on top of that. */}
             <TooltipTrigger asChild>
-              <Switch
-                id="top-domains-hide-local-discovery"
-                aria-label="Hide local service-discovery domains"
-                checked={hideLocalDiscovery}
-                onCheckedChange={(next) => {
-                  setHideLocalDiscovery(next);
-                  onPageChange(0);
-                }}
-              />
+              <span className="inline-flex">
+                <Switch
+                  id="top-domains-hide-local-discovery"
+                  aria-label="Hide local service-discovery domains"
+                  checked={hideLocalDiscovery}
+                  onCheckedChange={(next) => {
+                    setHideLocalDiscovery(next);
+                    onPageChange(0);
+                  }}
+                />
+              </span>
             </TooltipTrigger>
             <TooltipContent sideOffset={4}>
               Hide local service-discovery and special-use names (.arpa,

--- a/src/components/dashboard/statistics/top-list.tsx
+++ b/src/components/dashboard/statistics/top-list.tsx
@@ -90,6 +90,8 @@ interface TopListCardProps {
   description: string;
   icon: LucideIcon;
   filterControls?: TopListFilterControls;
+  /** Rendered beside the all/blocked toggle in the card header. */
+  headerExtra?: ReactNode;
   isLoading: boolean;
   isEmpty: boolean;
   skeletonRows: number;
@@ -102,6 +104,7 @@ export function TopListCard({
   description,
   icon: Icon,
   filterControls,
+  headerExtra,
   isLoading,
   isEmpty,
   skeletonRows,
@@ -137,6 +140,7 @@ export function TopListCard({
             </CardTitle>
             <CardDescription>{description}</CardDescription>
           </div>
+          {headerExtra}
           {filterControls ? <TopListFilterToggle {...filterControls} /> : null}
         </div>
       </CardHeader>

--- a/src/env.js
+++ b/src/env.js
@@ -28,6 +28,7 @@ export const env = createEnv({
       .optional(),
     DEMO_MODE: z.boolean().default(false),
     INSTANCE_NAME: z.string().optional(),
+    HIDE_LOCAL_DISCOVERY_DOMAINS: z.boolean().default(false),
   },
 
   /**
@@ -51,6 +52,8 @@ export const env = createEnv({
     BLOCKY_API_URL: process.env.BLOCKY_API_URL,
     BLOCKY_REQUEST_HEADERS: process.env.BLOCKY_REQUEST_HEADERS,
     DEMO_MODE: process.env.DEMO_MODE === "true",
+    HIDE_LOCAL_DISCOVERY_DOMAINS:
+      process.env.HIDE_LOCAL_DISCOVERY_DOMAINS === "true",
     INSTANCE_NAME: process.env.INSTANCE_NAME,
     // NEXT_PUBLIC_CLIENTVAR: process.env.NEXT_PUBLIC_CLIENTVAR,
   },

--- a/src/server/api/routers/blocky.ts
+++ b/src/server/api/routers/blocky.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { env } from "~/env";
 import { createTRPCRouter, publicProcedure } from "~/server/api/trpc";
 import {
   BLOCKY_API_UNAVAILABLE_MESSAGE,
@@ -119,6 +120,11 @@ export const blockyRouter = createTRPCRouter({
 
       return parseBlockyQueryResult(data);
     }),
+  features: publicProcedure.query(() => ({
+    // Only when the operator opts in does the UI offer the toggle.
+    localDiscoveryFilter: env.HIDE_LOCAL_DISCOVERY_DOMAINS,
+  })),
+
   getQueryLogs: publicProcedure
     .input(
       z
@@ -129,6 +135,7 @@ export const blockyRouter = createTRPCRouter({
           responseType: z.enum(BLOCKY_RESPONSE_TYPES).optional(),
           client: z.string().optional(),
           questionType: z.enum(BLOCKY_DNS_RECORD_TYPES).optional(),
+          hideLocalDiscovery: z.boolean().optional(),
         })
         .optional(),
     )
@@ -144,6 +151,7 @@ export const blockyRouter = createTRPCRouter({
         responseType: input?.responseType,
         client: input?.client,
         questionType: input?.questionType,
+        hideLocalDiscovery: input?.hideLocalDiscovery,
       });
     }),
 });

--- a/src/server/api/routers/stats.ts
+++ b/src/server/api/routers/stats.ts
@@ -49,13 +49,21 @@ export const statsRouter = createTRPCRouter({
     }),
 
   topList: publicProcedure
-    .input(paginatedRangeSchema.extend({ type: topListTypeSchema }))
+    .input(
+      paginatedRangeSchema.extend({
+        type: topListTypeSchema,
+        hideLocalDiscovery: z.boolean().optional(),
+      }),
+    )
     .query(async ({ ctx, input }) => {
       if (!ctx.logProvider) return null;
 
-      const { type, ...options } = input;
+      const { type, hideLocalDiscovery, ...options } = input;
       if (type === "domains") {
-        const result = await ctx.logProvider.getTopDomains(options);
+        const result = await ctx.logProvider.getTopDomains({
+          ...options,
+          hideLocalDiscovery,
+        });
         return {
           ...result,
           items: result.items.map((item) => ({

--- a/src/server/blocky/local-discovery.test.ts
+++ b/src/server/blocky/local-discovery.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isLocalDiscoveryDomain,
+  withoutLocalDiscoveryDomains,
+} from "~/server/blocky/local-discovery";
+
+describe("isLocalDiscoveryDomain", () => {
+  it.each([
+    "ipv4only.arpa",
+    "2.0.192.in-addr.arpa",
+    "1.0.0.0.ip6.arpa",
+    "localhost",
+    "db.localhost",
+    "localdomain",
+    "host.localdomain",
+    "lb._dns-sd._udp.2.0.192.in-addr.arpa",
+    "_dns-push-tls._tcp.ipv4only.arpa",
+    "_companion-link._tcp.home",
+    "ipv4only.arpa.",
+  ])("hides %s", (name) => {
+    expect(isLocalDiscoveryDomain(name)).toBe(true);
+  });
+
+  it.each([
+    "example.com",
+    "grafana.example.com",
+    "printer.local",
+    "server1.local",
+    "localhost.example.com",
+    "notlocal",
+    "arpa.example.com",
+    "my_tcp.example.com",
+  ])("keeps %s", (name) => {
+    expect(isLocalDiscoveryDomain(name)).toBe(false);
+  });
+});
+
+describe("withoutLocalDiscoveryDomains", () => {
+  it("removes only matching entries and preserves order", () => {
+    expect(
+      withoutLocalDiscoveryDomains([
+        { name: "example.com", count: 10 },
+        { name: "ipv4only.arpa", count: 900 },
+        { name: "grafana.example.com", count: 5 },
+      ]),
+    ).toEqual([
+      { name: "example.com", count: 10 },
+      { name: "grafana.example.com", count: 5 },
+    ]);
+  });
+});

--- a/src/server/blocky/local-discovery.ts
+++ b/src/server/blocky/local-discovery.ts
@@ -1,0 +1,66 @@
+/**
+ * Local service-discovery and special-use domains.
+ *
+ * These dominate the top-domain lists on a home network without saying anything
+ * useful: Apple devices probe NAT64 support via `ipv4only.arpa`, browse services
+ * via `lb._dns-sd._udp.<searchdomain>`, and every reverse lookup lands under
+ * `.arpa`. They are normal traffic, not a signal.
+ *
+ * Matching is on the query name only. Counts in the summary are untouched — this
+ * hides rows from the top lists, it does not change what was resolved.
+ */
+
+/** Suffixes matched against the full query name, case-insensitively. */
+export const SPECIAL_USE_SUFFIXES = [
+  ".arpa", // in-addr.arpa, ip6.arpa, ipv4only.arpa (RFC 6761, RFC 7050)
+  ".localhost", // RFC 6761
+  ".localdomain", // common DHCP default, not standardised
+];
+
+/*
+ * `.local` is deliberately NOT here. RFC 6762 reserves it for mDNS, but plenty of
+ * networks use it as an internal TLD, and those names are the ones an operator
+ * most wants to see. Hiding them would remove real infrastructure from the list.
+ */
+
+/**
+ * DNS-SD service labels (RFC 6763). Matched anywhere in the name, because the
+ * suffix is whatever search domain DHCP handed out:
+ *   lb._dns-sd._udp.2.0.192.in-addr.arpa
+ *   _dns-push-tls._tcp.ipv4only.arpa
+ */
+export const SERVICE_LABELS = ["._tcp.", "._udp."];
+
+/** Bare names with no dot that are still local-only. */
+export const BARE_LOCAL_NAMES = ["localhost", "localdomain"];
+
+export function isLocalDiscoveryDomain(name: string): boolean {
+  const value = name.toLowerCase().replace(/\.$/, "");
+
+  if (SPECIAL_USE_SUFFIXES.some((suffix) => value.endsWith(suffix))) {
+    return true;
+  }
+
+  // Also catch a bare label, e.g. "localhost" with no dot.
+  if (BARE_LOCAL_NAMES.includes(value)) {
+    return true;
+  }
+
+  return SERVICE_LABELS.some((label) => value.includes(label));
+}
+
+export function withoutLocalDiscoveryDomains<T extends { name: string }>(
+  entries: T[],
+): T[] {
+  return entries.filter((entry) => !isLocalDiscoveryDomain(entry.name));
+}
+
+/**
+ * Escape LIKE metacharacters so a pattern matches literally.
+ *
+ * `_` matches any single character and `%` any sequence, and the DNS-SD labels
+ * contain `_`. Paired with `ESCAPE '!'` at the call site.
+ */
+export function escapeLikePattern(value: string): string {
+  return value.replace(/[!%_]/g, (character) => `!${character}`);
+}

--- a/src/server/blocky/statistics.ts
+++ b/src/server/blocky/statistics.ts
@@ -1,6 +1,8 @@
 import { z } from "zod";
 
+import { env } from "~/env";
 import { blockyApi } from "~/server/blocky/client";
+import { withoutLocalDiscoveryDomains } from "~/server/blocky/local-discovery";
 
 const countByNameSchema = z.record(z.string(), z.number());
 
@@ -47,7 +49,10 @@ export async function fetchBlockyStatistics(): Promise<BlockyStatistics | null> 
   }
 }
 
-export function createStatisticsSnapshot(statistics: BlockyStatistics) {
+export function createStatisticsSnapshot(
+  statistics: BlockyStatistics,
+  hideLocalDiscovery: boolean = env.HIDE_LOCAL_DISCOVERY_DOMAINS,
+) {
   const { summary } = statistics;
   const blockedPercentage =
     summary.queries > 0 ? (summary.blocked / summary.queries) * 100 : 0;
@@ -75,8 +80,14 @@ export function createStatisticsSnapshot(statistics: BlockyStatistics) {
       allowlistDomains,
     },
     topLists: {
-      domains: statistics.topDomains,
-      blockedDomains: statistics.topBlockedDomains,
+      // Only the top lists are filtered. The summary counts above still reflect
+      // every query blocky answered.
+      domains: hideLocalDiscovery
+        ? withoutLocalDiscoveryDomains(statistics.topDomains)
+        : statistics.topDomains,
+      blockedDomains: hideLocalDiscovery
+        ? withoutLocalDiscoveryDomains(statistics.topBlockedDomains)
+        : statistics.topBlockedDomains,
       clients: statistics.topClients,
     },
   };

--- a/src/server/logs/aggregation-utils.ts
+++ b/src/server/logs/aggregation-utils.ts
@@ -1,4 +1,5 @@
 import { type TimeRange } from "~/lib/constants";
+import { isLocalDiscoveryDomain } from "~/server/blocky/local-discovery";
 import type {
   LogEntry,
   QueriesOverTimeEntry,
@@ -84,17 +85,28 @@ export function aggregateTopDomains(
   entries: LogEntry[],
   limit: number,
   offset: number,
+  hideLocalDiscovery = false,
 ): { items: TopDomainEntry[]; totalCount: number } {
   const domainStats = new Map<string, { count: number; blocked: number }>();
+  // Counted rather than using entries.length, so percentages are relative to the
+  // rows actually shown. The SQL providers compute their total with a window
+  // function over the filtered set, and the two paths must agree.
+  let includedCount = 0;
   for (const entry of entries) {
     const domain = entry.questionName ?? "unknown";
+    // Filtered here rather than after aggregating, so totals and pagination
+    // describe the same set of rows the caller is shown.
+    if (hideLocalDiscovery && isLocalDiscoveryDomain(domain)) {
+      continue;
+    }
+    includedCount++;
     const stats = domainStats.get(domain) ?? { count: 0, blocked: 0 };
     stats.count++;
     if (entry.responseType === "BLOCKED") stats.blocked++;
     domainStats.set(domain, stats);
   }
 
-  const totalQueriesCount = entries.length;
+  const totalQueriesCount = includedCount;
   const sortedDomains = Array.from(domainStats.entries()).sort(
     (a, b) => b[1].count - a[1].count || a[0].localeCompare(b[0]),
   );

--- a/src/server/logs/base-provider.ts
+++ b/src/server/logs/base-provider.ts
@@ -116,10 +116,16 @@ export abstract class BaseMemoryLogProvider implements LogProvider {
     limit: number;
     offset: number;
     filter: "all" | "blocked";
+    hideLocalDiscovery?: boolean;
   }): Promise<{ items: TopDomainEntry[]; totalCount: number }> {
     const entries = await this.getEntriesInRange(options.range);
     const filtered = filterByBlocked(entries, options.filter);
-    return aggregateTopDomains(filtered, options.limit, options.offset);
+    return aggregateTopDomains(
+      filtered,
+      options.limit,
+      options.offset,
+      options.hideLocalDiscovery,
+    );
   }
 
   async getTopClients(options: {

--- a/src/server/logs/csv/utils.ts
+++ b/src/server/logs/csv/utils.ts
@@ -1,4 +1,5 @@
 import * as fs from "fs";
+import { isLocalDiscoveryDomain } from "~/server/blocky/local-discovery";
 import * as readline from "readline";
 import type { LogEntry, QueryLogsOptions } from "../types";
 
@@ -88,7 +89,7 @@ export function streamAndParseEntries(
 export function createFilterFn(
   options: Pick<
     QueryLogsOptions,
-    "search" | "responseType" | "client" | "questionType"
+    "search" | "responseType" | "client" | "questionType" | "hideLocalDiscovery"
   >,
 ): (entry: LogEntry) => boolean {
   const searchLower = options.search?.toLowerCase();
@@ -105,8 +106,17 @@ export function createFilterFn(
       entry.clientName?.toLowerCase().includes(clientLower) === true;
     const passesQuestionType =
       !options.questionType || entry.questionType === options.questionType;
+    // A missing question name is not a local-discovery name, so it is kept.
+    const passesLocalDiscovery =
+      !options.hideLocalDiscovery ||
+      !entry.questionName ||
+      !isLocalDiscoveryDomain(entry.questionName);
     return (
-      passesSearch && passesResponseType && passesClient && passesQuestionType
+      passesSearch &&
+      passesResponseType &&
+      passesClient &&
+      passesQuestionType &&
+      passesLocalDiscovery
     );
   };
 }

--- a/src/server/logs/sql/base-provider.ts
+++ b/src/server/logs/sql/base-provider.ts
@@ -16,6 +16,12 @@ import {
   type Column,
 } from "drizzle-orm";
 import { type TimeRange } from "~/lib/constants";
+import {
+  BARE_LOCAL_NAMES,
+  escapeLikePattern,
+  SERVICE_LABELS,
+  SPECIAL_USE_SUFFIXES,
+} from "~/server/blocky/local-discovery";
 import { getTimeRangeConfig } from "~/server/logs/aggregation-utils";
 import type {
   LogProvider,
@@ -146,6 +152,48 @@ export abstract class BaseSqlLogProvider implements LogProvider {
     return filters;
   }
 
+  /**
+   * Exclude local discovery names from the top-domain aggregation.
+   *
+   * This has to happen in the WHERE clause, not after the query returns: the
+   * aggregation is grouped, paginated with limit/offset, and totals come from
+   * window functions over the matched set. Filtering rows afterwards would leave
+   * short pages and totals that disagree with what is displayed.
+   */
+  private buildLocalDiscoveryFilters(hide: boolean | undefined): SqlFilter[] {
+    if (!hide) return [];
+
+    const column = this.columns.questionName;
+
+    // LOWER() on both sides, matching how search filters are written elsewhere in
+    // this file. LIKE is case-sensitive on PostgreSQL but not on MySQL or SQLite,
+    // so a bare comparison would filter different rows per dialect -- and neither
+    // would agree with isLocalDiscoveryDomain(), which lowercases.
+    //
+    // Patterns are escaped because `_` is a single-character LIKE wildcard, and the
+    // DNS-SD labels contain one: an unescaped `%._tcp.%` also matches `foo.xtcp.bar`.
+    // ESCAPE is supported by PostgreSQL, MySQL and SQLite alike. `!` is used rather
+    // than a backslash, which MySQL also treats as a string escape.
+    const like = (pattern: string) =>
+      sql`LOWER(${column}) NOT LIKE ${pattern} ESCAPE '!'`;
+
+    const conditions: SqlFilter[] = [
+      // Trailing dot is not stored by blocky, so a plain suffix match is enough.
+      ...SPECIAL_USE_SUFFIXES.map((suffix) =>
+        like(`%${escapeLikePattern(suffix.toLowerCase())}`),
+      ),
+      ...SERVICE_LABELS.map((label) =>
+        like(`%${escapeLikePattern(label.toLowerCase())}%`),
+      ),
+      sql`LOWER(${column}) NOT IN ${BARE_LOCAL_NAMES.map((n) => n.toLowerCase())}`,
+    ];
+
+    // A NULL question name is not a local-discovery name, but `NULL NOT LIKE ...`
+    // evaluates to NULL rather than true, so without this those rows disappear from
+    // the results whenever the filter is on.
+    return [sql`(${column} IS NULL OR (${and(...conditions)}))`];
+  }
+
   private async getGroupedTotals(options: {
     filters: SqlFilter[];
     groupColumn: Column;
@@ -236,6 +284,10 @@ export abstract class BaseSqlLogProvider implements LogProvider {
     if (options.questionType) {
       filters.push(eq(this.columns.questionType, options.questionType));
     }
+
+    filters.push(
+      ...this.buildLocalDiscoveryFilters(options.hideLocalDiscovery),
+    );
 
     const countQuery = this.db
       .select({ count: sql<number>`count(*)` })
@@ -344,8 +396,12 @@ export abstract class BaseSqlLogProvider implements LogProvider {
     limit: number;
     offset: number;
     filter: "all" | "blocked";
+    hideLocalDiscovery?: boolean;
   }): Promise<{ items: TopDomainEntry[]; totalCount: number }> {
-    const filters = this.buildRangeFilters(options);
+    const filters = [
+      ...this.buildRangeFilters(options),
+      ...this.buildLocalDiscoveryFilters(options.hideLocalDiscovery),
+    ];
 
     const result = await this.db
       .select({

--- a/src/server/logs/types.ts
+++ b/src/server/logs/types.ts
@@ -66,6 +66,8 @@ export interface QueryLogsOptions {
   responseType?: string;
   client?: string;
   questionType?: string;
+  /** Exclude local service-discovery and special-use names. */
+  hideLocalDiscovery?: boolean;
 }
 
 export interface QueryLogsResult {
@@ -91,6 +93,7 @@ export interface LogProvider {
     limit: number;
     offset: number;
     filter: "all" | "blocked";
+    hideLocalDiscovery?: boolean;
   }): Promise<{ items: TopDomainEntry[]; totalCount: number }>;
 
   getTopClients(options: {


### PR DESCRIPTION
- [x] I have searched existing issues and pull requests (including closed ones) to ensure this isn't a duplicate
- [x] I have read CONTRIBUTING.md

## Human Written Description

<!-- DRAFT — rewrite in your own words before submitting -->

I use blocky at home with some Apple devices, and the Top Domains list was almost useless because of it. The top five entries were things like `_grpclb._tcp.localhost`, `ipv4only.arpa` and `lb._dns-sd._udp.<searchdomain>` normal background chatter that pushed everything I actually cared about off the list.

I didn't want them being dropped because this is what Blocky's docs say:

> Under certain circumstances, it may be useful to filter some types of DNS queries. You can define one or more DNS query types, all queries with these types will be dropped (empty answer will be returned).

```yaml
filtering:
  queryTypes:
    - AAAA
```

, but just out of the way by default. So this adds an opt-in switch rather than filtering unconditionally.

## Related Issues/Discussions

No existing issue or PR covers this — I searched open and closed.

## Testing

Tested locally against my own blocky instance, using the built Docker image pointed at a real Postgres query log and the blocky API.

Ran three containers side by side: `HIDE_LOCAL_DISCOVERY_DOMAINS=true`, `=false` and unset 

Verified:
- Top Domains and the raw Query Logs listing both filter, and both restore when
  the switch is turned off
- Applies to both the all and blocked views
- Summary counts are unchanged either way
- Toggling resets to page 1
- Case handling on Postgres: `IPv4Only.ARPA`, `LOCALHOST` and
  `LB._DNS-SD._UDP.LocalDomain` are hidden; `Example.COM` is kept

`bun run verify` passes. `bun run test` passes except one testcontainers file that fails on container networking in my environment (containerised test runner on Docker Desktop) — 6/7 files, 55 tests. The new `local-discovery.test.ts` passes with 20 tests.

## Screenshots/Videos

When the feature is enabled:
<img width="3950" height="4982" alt="BlockyUI-feature-ON" src="https://github.com/user-attachments/assets/ef14581f-b153-465f-b174-08c15060de3a" />

When the environment variable is set to `false`:

<img width="3950" height="4982" alt="BlockyUI-feature-OFF" src="https://github.com/user-attachments/assets/026680c1-50c4-4ebb-acea-a39aa60078be" />

When the environment variable is unset:

<img width="3950" height="4982" alt="BlockyUI-env-UNSET" src="https://github.com/user-attachments/assets/5d30ff1b-4418-4a1d-9160-83add8337151" />


## AI Assistance

- [x] AI was used in this PR

**If AI was used:**

- Tools used: Claude Code
- How extensively: Substantially — it wrote the implementation and tests (including this AI Assistance declaration :) ). I directed the design and reviewed every change. Several things came out of that review rather than the first draft: the filter originally only covered blocky's  `/api/stats` and missed the query log entirely; it was unconditional with no way to see the hidden traffic, which became the switch; and the SQL used a bare `notLike`, which is case-sensitive on Postgres but not MySQL/SQLite, so it would have behaved differently per backend. All tested against my own instance (w/Postgres) before submitting.