### PR TITLE
Improve query-log ordering and SQL pagination

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -22,6 +22,7 @@
         "class-variance-authority": "0.7.1",
         "clsx": "2.1.1",
         "cmdk": "1.1.1",
+        "csv-parse": "7.0.2",
         "date-fns": "4.4.0",
         "drizzle-orm": "0.45.2",
         "ky": "2.0.2",
@@ -928,6 +929,8 @@
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
+    "csv-parse": ["csv-parse@7.0.2", "", {}, "sha512-uKZghv9UmPkMVLYy//KZ9HFAIJsl7wkhoEdIL0+rhuSY9pZQlhaeGEDPIe+/w7eh81MOql8Q/9+inAGWG6ZHYA=="],
 
     "d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
 

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "sonner": "2.0.7",
     "superjson": "2.2.6",
     "tailwind-merge": "3.6.0",
-    "zod": "4.4.3"
+    "zod": "4.4.3",
+    "csv-parse": "7.0.2"
   },
   "devDependencies": {
     "@changesets/changelog-github": "0.7.0",

--- a/src/server/logs/__tests__/mysql-query-paths.test.ts
+++ b/src/server/logs/__tests__/mysql-query-paths.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createConnection } from "mysql2/promise";
-import { makeEntry, setupMysql } from "./setup";
+import { makeEntry, setupMysql } from "~/server/logs/__tests__/setup";
 
 const rowCount = 70_000;
 const timestamp = Date.now() - rowCount * 1000;

--- a/src/server/logs/__tests__/mysql-query-paths.test.ts
+++ b/src/server/logs/__tests__/mysql-query-paths.test.ts
@@ -1,0 +1,137 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createConnection } from "mysql2/promise";
+import { makeEntry, setupMysql } from "./setup";
+
+const rowCount = 70_000;
+const timestamp = Date.now() - rowCount * 1000;
+const hostnames = ["nas", "NAS", "nás", "nas ", "", null];
+const sparseIds = [1, 2, 3, 4, rowCount - 1, rowCount];
+let fixture: Awaited<ReturnType<typeof setupMysql>>;
+
+beforeAll(async () => {
+  fixture = await setupMysql(
+    Array.from({ length: rowCount }, (_, index) =>
+      makeEntry({
+        requestTs: new Date(timestamp + index * 1000).toISOString(),
+        questionName: sparseIds.includes(index + 1)
+          ? "sparse.test"
+          : "dense.test",
+        hostname: hostnames[index % hostnames.length],
+      }),
+    ),
+  );
+}, 120_000);
+
+afterAll(async () => {
+  await fixture?.provider.close();
+  await fixture?.container.stop();
+}, 30_000);
+
+describe("MySQL query paths with retained history", () => {
+  it("excludes only exact hostnames from rows, counts and aggregations", async () => {
+    const excludedHostnames = ["nas"];
+    const expected = rowCount - Math.ceil(rowCount / hostnames.length);
+    const scope = { excludedHostnames };
+    const rows = await fixture.provider.getQueryLogRows({
+      ...scope,
+      limit: 20,
+      offset: 0,
+    });
+
+    expect(rows.map((row) => row.hostname)).toEqual(
+      expect.arrayContaining(["NAS", "nás", "nas ", "", null]),
+    );
+    expect(rows.some((row) => row.hostname === "nas")).toBe(false);
+    expect(await fixture.provider.getQueryLogCount(scope)).toBe(expected);
+    expect(
+      await fixture.provider.getQueryLogCountSince(scope, new Date(0)),
+    ).toBe(expected);
+    const top = await fixture.provider.getTopDomains({
+      ...scope,
+      range: "24h",
+      filter: "all",
+      offset: 0,
+    });
+    expect(top.items.reduce((total, row) => total + row.count, 0)).toBe(
+      expected,
+    );
+    const buckets = await fixture.provider.getQueriesOverTime({
+      ...scope,
+      range: "24h",
+    });
+    expect(buckets.reduce((total, bucket) => total + bucket.total, 0)).toBe(
+      expected,
+    );
+  });
+
+  it("paginates dense recent matches and sparse matches spanning the recent boundary", async () => {
+    const dense = await fixture.provider.getQueryLogRows({
+      search: "dense.test",
+      limit: 5,
+      offset: 3,
+    });
+    expect(dense.map((row) => row.id)).toEqual([
+      69_995, 69_994, 69_993, 69_992, 69_991,
+    ]);
+    const sparse = await fixture.provider.getQueryLogRows({
+      search: "sparse.test",
+      limit: 3,
+      offset: 2,
+    });
+    expect(sparse.map((row) => row.id)).toEqual([4, 3, 2]);
+    expect(
+      await fixture.provider.getQueryLogCount({ search: "sparse.test" }),
+    ).toBe(6);
+    const deep = await fixture.provider.getQueryLogRows({
+      search: "dense.test",
+      limit: 3,
+      offset: 65_537,
+    });
+    expect(deep.map((row) => row.id)).toEqual([4461, 4460, 4459]);
+    expect(
+      await fixture.provider.getQueryLogRows({
+        search: "sparse.test",
+        limit: 3,
+        offset: 10,
+      }),
+    ).toEqual([]);
+  });
+
+  it("keeps new arrivals outside the ID snapshot for search rows and counts", async () => {
+    const maxId = await fixture.provider.getQueryLogSnapshot();
+    const connection = await createConnection(
+      fixture.container.getConnectionUri(),
+    );
+
+    try {
+      await connection.execute(
+        "INSERT INTO log_entries (request_ts, question_name, hostname) VALUES (?, ?, ?)",
+        [
+          new Date().toISOString().replace("T", " ").replace("Z", ""),
+          "sparse.test",
+          "NAS",
+        ],
+      );
+    } finally {
+      await connection.end();
+    }
+
+    const filter = { search: "sparse.test", maxId };
+    expect(await fixture.provider.getQueryLogCount(filter)).toBe(6);
+    expect(
+      await fixture.provider.getQueryLogCountSince(filter, new Date(0)),
+    ).toBe(6);
+    expect(
+      (
+        await fixture.provider.getQueryLogRows({
+          ...filter,
+          limit: 3,
+          offset: 1,
+        })
+      ).map((row) => row.id),
+    ).toEqual([69_999, 4, 3]);
+    expect(
+      await fixture.provider.getQueryLogCount({ search: "sparse.test" }),
+    ).toBe(7);
+  });
+});

--- a/src/server/logs/__tests__/provider-boundaries.test.ts
+++ b/src/server/logs/__tests__/provider-boundaries.test.ts
@@ -2,12 +2,21 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import Database from "better-sqlite3";
+import { type Pool } from "mysql2/promise";
+import { type Sql } from "postgres";
+import { MySQLLogProvider } from "~/server/logs/mysql/provider";
+import { PostgreSQLLogProvider } from "~/server/logs/postgres/provider";
 import { afterEach, expect, it, vi } from "vitest";
 import { aggregateQueriesOverTime } from "~/server/logs/aggregation-utils";
 import { CsvLogProvider } from "~/server/logs/csv/provider";
 import { CsvClientLogProvider } from "~/server/logs/csv/client-provider";
 import { SQLiteLogProvider } from "~/server/logs/sqlite/provider";
-import { entryToCsvLine, makeEntry } from "~/server/logs/__tests__/setup";
+import {
+  entryToCsvLine,
+  makeEntry,
+  setupMysql,
+  setupPostgres,
+} from "~/server/logs/__tests__/setup";
 
 afterEach(() => vi.restoreAllMocks());
 
@@ -84,3 +93,61 @@ it("leaves shared SQLite connections open for their cache owner", async () => {
     await rm(directory, { recursive: true, force: true });
   }
 });
+
+it.each([
+  {
+    name: "MySQL",
+    setup: setupMysql,
+    cache(connectionUri: string) {
+      const connections = new Map<string, Pool>();
+      return {
+        provider: () => new MySQLLogProvider({ connectionUri, connections }),
+        async close() {
+          for (const connection of connections.values()) {
+            await connection.end();
+          }
+        },
+      };
+    },
+  },
+  {
+    name: "PostgreSQL",
+    setup: setupPostgres,
+    cache(connectionUri: string) {
+      const connections = new Map<string, Sql>();
+      return {
+        provider: () =>
+          new PostgreSQLLogProvider({ connectionUri, connections }),
+        async close() {
+          for (const connection of connections.values()) {
+            await connection.end();
+          }
+        },
+      };
+    },
+  },
+])(
+  "leaves shared $name connections open for their cache owner",
+  async ({ setup, cache }) => {
+    const fixture = await setup([makeEntry()]);
+    const shared = cache(fixture.container.getConnectionUri());
+
+    try {
+      const first = shared.provider();
+      const second = shared.provider();
+      await first.close();
+
+      expect(await second.getQueryLogCount({})).toBe(1);
+      await second.close();
+
+      const third = shared.provider();
+      expect(await third.getQueryLogCount({})).toBe(1);
+      await third.close();
+    } finally {
+      await shared.close();
+      await fixture.provider.close();
+      await fixture.container.stop();
+    }
+  },
+  60_000,
+);

--- a/src/server/logs/__tests__/provider-boundaries.test.ts
+++ b/src/server/logs/__tests__/provider-boundaries.test.ts
@@ -1,0 +1,86 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import Database from "better-sqlite3";
+import { afterEach, expect, it, vi } from "vitest";
+import { aggregateQueriesOverTime } from "~/server/logs/aggregation-utils";
+import { CsvLogProvider } from "~/server/logs/csv/provider";
+import { CsvClientLogProvider } from "~/server/logs/csv/client-provider";
+import { SQLiteLogProvider } from "~/server/logs/sqlite/provider";
+import { entryToCsvLine, makeEntry } from "~/server/logs/__tests__/setup";
+
+afterEach(() => vi.restoreAllMocks());
+
+it("excludes future events even within the current chart bucket", () => {
+  vi.spyOn(Date, "now").mockReturnValue(Date.parse("2026-09-10T10:02:00Z"));
+
+  const result = aggregateQueriesOverTime(
+    ["10:01", "10:02", "10:04"].map((time) =>
+      makeEntry({ requestTs: `2026-09-10T${time}:00Z` }),
+    ),
+    "1h",
+  );
+
+  expect(result.at(-1)?.total).toBe(2);
+});
+
+it.each([CsvLogProvider, CsvClientLogProvider])(
+  "%s orders offset timestamps by instant and returns invalid timestamps as null",
+  async (Provider) => {
+    const directory = await mkdtemp(join(tmpdir(), "csv-timestamps-"));
+
+    try {
+      const entries = [
+        "2026-09-10T12:00:00+02:00",
+        "invalid",
+        "2026-09-10T11:00:00Z",
+      ];
+      await writeFile(
+        join(directory, "2026-09-10_client.log"),
+        entries
+          .map((requestTs) => entryToCsvLine(makeEntry({ requestTs })))
+          .join("\n"),
+      );
+
+      const result = await new Provider({ directory }).getQueryLogs({
+        limit: 10,
+        offset: 0,
+      });
+
+      expect(result.items.map((entry) => entry.requestTs)).toEqual([
+        "2026-09-10T11:00:00.000Z",
+        "2026-09-10T10:00:00.000Z",
+        null,
+      ]);
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  },
+);
+
+it("leaves shared SQLite connections open for their cache owner", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "sqlite-ownership-"));
+  const filePath = join(directory, "blocky.db");
+  const seed = new Database(filePath);
+  seed.close();
+  const connections = new Map<string, Database.Database>();
+
+  try {
+    const first = new SQLiteLogProvider({ filePath, connections });
+    const second = new SQLiteLogProvider({ filePath, connections });
+    await first.close();
+    await second.close();
+
+    expect(
+      connections.get(filePath)?.prepare("SELECT 1 AS value").get(),
+    ).toEqual({ value: 1 });
+    const third = new SQLiteLogProvider({ filePath, connections });
+    await third.close();
+    expect(connections.size).toBe(1);
+  } finally {
+    for (const connection of connections.values()) {
+      connection.close();
+    }
+    await rm(directory, { recursive: true, force: true });
+  }
+});

--- a/src/server/logs/__tests__/seed-data.ts
+++ b/src/server/logs/__tests__/seed-data.ts
@@ -565,7 +565,15 @@ export function createSeedData(): LogEntry[] {
     return tsB.localeCompare(tsA);
   });
 
-  return entries;
+  return entries.map((entry, index) => ({
+    ...entry,
+    hostname:
+      index % 3 === 0
+        ? null
+        : index % 3 === 1
+          ? "blocky-instance-1"
+          : "blocky-instance-2",
+  }));
 }
 
 export function countEntriesInRange(

--- a/src/server/logs/__tests__/setup.ts
+++ b/src/server/logs/__tests__/setup.ts
@@ -151,7 +151,7 @@ function entryToMysqlRow(entry: LogEntry): unknown[] {
   ];
 }
 
-async function setupMysql(entries: LogEntry[]): Promise<{
+export async function setupMysql(entries: LogEntry[]): Promise<{
   provider: MySQLLogProvider;
   container: StartedMySqlContainer;
 }> {
@@ -166,8 +166,8 @@ async function setupMysql(entries: LogEntry[]): Promise<{
     try {
       await connection.execute(CREATE_TABLE_SQL);
 
-      if (entries.length > 0) {
-        const rows = entries.map(entryToMysqlRow);
+      for (let offset = 0; offset < entries.length; offset += 1000) {
+        const rows = entries.slice(offset, offset + 1000).map(entryToMysqlRow);
         await connection.query(INSERT_SQL, [rows]);
       }
     } finally {

--- a/src/server/logs/__tests__/setup.ts
+++ b/src/server/logs/__tests__/setup.ts
@@ -30,7 +30,7 @@ import { CsvLogProvider } from "~/server/logs/csv/provider";
 import { CsvClientLogProvider } from "~/server/logs/csv/client-provider";
 import { VictoriaLogsProvider } from "~/server/logs/victorialogs/provider";
 import { type LogEntry, type LogProvider } from "~/server/logs/types";
-import { createSeedData } from "./seed-data";
+import { createSeedData } from "~/server/logs/__tests__/seed-data";
 
 const CREATE_TABLE_SQL = `
   CREATE TABLE IF NOT EXISTS log_entries (
@@ -182,7 +182,7 @@ export async function setupMysql(entries: LogEntry[]): Promise<{
   }
 }
 
-async function setupPostgres(entries: LogEntry[]): Promise<{
+export async function setupPostgres(entries: LogEntry[]): Promise<{
   provider: PostgreSQLLogProvider;
   container: StartedPostgreSqlContainer;
 }> {

--- a/src/server/logs/aggregation-utils.ts
+++ b/src/server/logs/aggregation-utils.ts
@@ -1,3 +1,4 @@
+import type { SearchDomainEntry, SearchClientEntry } from "./types";
 import { type TimeRange } from "~/lib/constants";
 import type {
   LogEntry,
@@ -5,14 +6,11 @@ import type {
   TopDomainEntry,
   TopClientEntry,
   QueryTypeEntry,
-  SearchDomainEntry,
-  SearchClientEntry,
 } from "./types";
 
 export interface TimeRangeConfig {
   startTime: Date;
   interval: number;
-  bucketCount: number;
 }
 
 export function getTimeRangeConfig(range: TimeRange): TimeRangeConfig {
@@ -22,25 +20,21 @@ export function getTimeRangeConfig(range: TimeRange): TimeRangeConfig {
       return {
         startTime: new Date(now - 60 * 60 * 1000),
         interval: 5 * 60 * 1000,
-        bucketCount: 12,
       };
     case "24h":
       return {
         startTime: new Date(now - 24 * 60 * 60 * 1000),
         interval: 60 * 60 * 1000,
-        bucketCount: 24,
       };
     case "7d":
       return {
         startTime: new Date(now - 7 * 24 * 60 * 60 * 1000),
         interval: 6 * 60 * 60 * 1000,
-        bucketCount: 28,
       };
     case "30d":
       return {
         startTime: new Date(now - 30 * 24 * 60 * 60 * 1000),
         interval: 24 * 60 * 60 * 1000,
-        bucketCount: 30,
       };
   }
 }
@@ -49,35 +43,35 @@ export function aggregateQueriesOverTime(
   entries: LogEntry[],
   range: TimeRange,
 ): QueriesOverTimeEntry[] {
-  const { startTime, interval, bucketCount } = getTimeRangeConfig(range);
-
-  const buckets: Map<number, QueriesOverTimeEntry> = new Map();
-  for (let i = 0; i < bucketCount; i++) {
-    const time = new Date(startTime.getTime() + i * interval);
-    buckets.set(i, {
-      time: time.toISOString(),
+  const { startTime, interval } = getTimeRangeConfig(range);
+  const buckets = new Map<number, QueriesOverTimeEntry>();
+  const now = Date.now();
+  const firstBucket = Math.floor(startTime.getTime() / interval) * interval;
+  for (let time = firstBucket; time <= now; time += interval) {
+    buckets.set(time, {
+      time: new Date(time).toISOString(),
       total: 0,
       blocked: 0,
       cached: 0,
     });
   }
-
   for (const entry of entries) {
-    const entryTime = new Date(entry.requestTs ?? 0).getTime();
-    const bucketIndex = Math.floor(
-      (entryTime - startTime.getTime()) / interval,
-    );
-    if (bucketIndex >= 0 && bucketIndex < bucketCount) {
-      const bucket = buckets.get(bucketIndex);
-      if (bucket) {
-        bucket.total++;
-        if (entry.responseType === "BLOCKED") bucket.blocked++;
-        if (entry.responseType === "CACHED") bucket.cached++;
+    const time = new Date(entry.requestTs ?? 0).getTime();
+    if (time < startTime.getTime()) {
+      continue;
+    }
+    const bucket = buckets.get(Math.floor(time / interval) * interval);
+    if (bucket) {
+      bucket.total++;
+      if (entry.responseType === "BLOCKED") {
+        bucket.blocked++;
+      }
+      if (entry.responseType === "CACHED") {
+        bucket.cached++;
       }
     }
   }
-
-  return Array.from(buckets.values());
+  return [...buckets.values()];
 }
 
 export function aggregateTopDomains(

--- a/src/server/logs/aggregation-utils.ts
+++ b/src/server/logs/aggregation-utils.ts
@@ -57,7 +57,7 @@ export function aggregateQueriesOverTime(
   }
   for (const entry of entries) {
     const time = new Date(entry.requestTs ?? 0).getTime();
-    if (time < startTime.getTime()) {
+    if (time < startTime.getTime() || time > now) {
       continue;
     }
     const bucket = buckets.get(Math.floor(time / interval) * interval);

--- a/src/server/logs/aggregation-utils.ts
+++ b/src/server/logs/aggregation-utils.ts
@@ -1,12 +1,13 @@
-import type { SearchDomainEntry, SearchClientEntry } from "./types";
 import { type TimeRange } from "~/lib/constants";
-import type {
-  LogEntry,
-  QueriesOverTimeEntry,
-  TopDomainEntry,
-  TopClientEntry,
-  QueryTypeEntry,
-} from "./types";
+import {
+  type SearchDomainEntry,
+  type SearchClientEntry,
+  type LogEntry,
+  type QueriesOverTimeEntry,
+  type TopDomainEntry,
+  type TopClientEntry,
+  type QueryTypeEntry,
+} from "~/server/logs/types";
 
 export interface TimeRangeConfig {
   startTime: Date;

--- a/src/server/logs/base-provider.ts
+++ b/src/server/logs/base-provider.ts
@@ -1,22 +1,30 @@
+import type {
+  StatsResult,
+  SearchDomainEntry,
+  SearchClientEntry,
+} from "./types";
+import {
+  searchDomainsInEntries,
+  searchClientsInEntries,
+} from "./aggregation-utils";
+import { isEntryInScope } from "~/server/logs/scope";
 import { type TimeRange } from "~/lib/constants";
 import type {
   LogProvider,
+  LogScope,
+  QueryLogsOptions,
+  QueryLogFilters,
   LogEntry,
-  StatsResult,
   QueriesOverTimeEntry,
   TopDomainEntry,
   TopClientEntry,
   QueryTypeEntry,
-  SearchDomainEntry,
-  SearchClientEntry,
 } from "./types";
 import {
   aggregateQueriesOverTime,
   aggregateTopDomains,
   aggregateTopClients,
   aggregateQueryTypes,
-  searchDomainsInEntries,
-  searchClientsInEntries,
 } from "./aggregation-utils";
 
 interface CacheEntry {
@@ -67,19 +75,31 @@ function filterByBlocked(
 export abstract class BaseMemoryLogProvider implements LogProvider {
   private readonly entriesCache = new Map<TimeRange, CacheEntry>();
 
-  abstract getQueryLogs(options: {
-    limit: number;
-    offset: number;
-    search?: string;
-    responseType?: string;
-    client?: string;
-  }): Promise<{ items: LogEntry[]; totalCount: number }>;
+  abstract getQueryLogs(
+    options: QueryLogsOptions,
+  ): Promise<{ items: LogEntry[]; totalCount: number }>;
 
-  abstract getStats24h(): Promise<StatsResult>;
+  async getQueryLogRows(options: QueryLogsOptions): Promise<LogEntry[]> {
+    return (await this.getQueryLogs(options)).items;
+  }
+
+  async getQueryLogCount(options: QueryLogFilters): Promise<number> {
+    return (await this.getQueryLogs({ ...options, limit: 0, offset: 0 }))
+      .totalCount;
+  }
 
   protected abstract fetchEntriesInRange(range: TimeRange): Promise<LogEntry[]>;
 
-  protected getEntriesInRange(range: TimeRange): Promise<LogEntry[]> {
+  protected async getEntriesInRange(
+    range: TimeRange,
+    scope: LogScope = {},
+  ): Promise<LogEntry[]> {
+    return (await this.getUnfilteredEntriesInRange(range)).filter((entry) =>
+      isEntryInScope(entry, scope),
+    );
+  }
+
+  private getUnfilteredEntriesInRange(range: TimeRange): Promise<LogEntry[]> {
     const cached = this.entriesCache.get(range);
     if (cached && Date.now() - cached.timestamp < CACHE_TTL_MS) {
       return cached.promise;
@@ -97,12 +117,14 @@ export abstract class BaseMemoryLogProvider implements LogProvider {
     return promise;
   }
 
-  async getQueriesOverTime(options: {
-    range: TimeRange;
-    domain?: string;
-    client?: string;
-  }): Promise<QueriesOverTimeEntry[]> {
-    const entries = await this.getEntriesInRange(options.range);
+  async getQueriesOverTime(
+    options: LogScope & {
+      range: TimeRange;
+      domain?: string;
+      client?: string;
+    },
+  ): Promise<QueriesOverTimeEntry[]> {
+    const entries = await this.getEntriesInRange(options.range, options);
     const filtered = filterByDomainAndClient(
       entries,
       options.domain,
@@ -111,31 +133,55 @@ export abstract class BaseMemoryLogProvider implements LogProvider {
     return aggregateQueriesOverTime(filtered, options.range);
   }
 
-  async getTopDomains(options: {
-    range: TimeRange;
-    limit: number;
-    offset: number;
-    filter: "all" | "blocked";
-  }): Promise<{ items: TopDomainEntry[]; totalCount: number }> {
-    const entries = await this.getEntriesInRange(options.range);
+  async getTopDomains(
+    options: LogScope & {
+      range: TimeRange;
+      limit?: number;
+      offset: number;
+      filter: "all" | "blocked";
+    },
+  ): Promise<{ items: TopDomainEntry[]; totalCount: number }> {
+    const entries = await this.getEntriesInRange(options.range, options);
     const filtered = filterByBlocked(entries, options.filter);
-    return aggregateTopDomains(filtered, options.limit, options.offset);
+    return aggregateTopDomains(
+      filtered,
+      options.limit ?? filtered.length,
+      options.offset,
+    );
   }
 
-  async getTopClients(options: {
-    range: TimeRange;
-    limit: number;
-    offset: number;
-    filter: "all" | "blocked";
-  }): Promise<{ items: TopClientEntry[]; totalCount: number }> {
-    const entries = await this.getEntriesInRange(options.range);
+  async getTopClients(
+    options: LogScope & {
+      range: TimeRange;
+      limit?: number;
+      offset: number;
+      filter: "all" | "blocked";
+    },
+  ): Promise<{ items: TopClientEntry[]; totalCount: number }> {
+    const entries = await this.getEntriesInRange(options.range, options);
     const filtered = filterByBlocked(entries, options.filter);
-    return aggregateTopClients(filtered, options.limit, options.offset);
+    return aggregateTopClients(
+      filtered,
+      options.limit ?? filtered.length,
+      options.offset,
+    );
   }
 
-  async getQueryTypesBreakdown(range: TimeRange): Promise<QueryTypeEntry[]> {
-    const entries = await this.getEntriesInRange(range);
+  async getQueryTypesBreakdown(
+    range: TimeRange,
+    scope: LogScope = {},
+  ): Promise<QueryTypeEntry[]> {
+    const entries = await this.getEntriesInRange(range, scope);
     return aggregateQueryTypes(entries);
+  }
+
+  async getStats24h(): Promise<StatsResult> {
+    const entries = await this.getEntriesInRange("24h");
+    return {
+      totalQueries: entries.length,
+      blocked: entries.filter((entry) => entry.responseType === "BLOCKED")
+        .length,
+    };
   }
 
   async searchDomains(options: {

--- a/src/server/logs/base-provider.ts
+++ b/src/server/logs/base-provider.ts
@@ -1,31 +1,31 @@
-import type {
-  StatsResult,
-  SearchDomainEntry,
-  SearchClientEntry,
-} from "./types";
+import {
+  type StatsResult,
+  type SearchDomainEntry,
+  type SearchClientEntry,
+} from "~/server/logs/types";
 import {
   searchDomainsInEntries,
   searchClientsInEntries,
-} from "./aggregation-utils";
+} from "~/server/logs/aggregation-utils";
 import { isEntryInScope } from "~/server/logs/scope";
 import { type TimeRange } from "~/lib/constants";
-import type {
-  LogProvider,
-  LogScope,
-  QueryLogsOptions,
-  QueryLogFilters,
-  LogEntry,
-  QueriesOverTimeEntry,
-  TopDomainEntry,
-  TopClientEntry,
-  QueryTypeEntry,
-} from "./types";
+import {
+  type LogProvider,
+  type LogScope,
+  type QueryLogsOptions,
+  type QueryLogFilters,
+  type LogEntry,
+  type QueriesOverTimeEntry,
+  type TopDomainEntry,
+  type TopClientEntry,
+  type QueryTypeEntry,
+} from "~/server/logs/types";
 import {
   aggregateQueriesOverTime,
   aggregateTopDomains,
   aggregateTopClients,
   aggregateQueryTypes,
-} from "./aggregation-utils";
+} from "~/server/logs/aggregation-utils";
 
 interface CacheEntry {
   promise: Promise<LogEntry[]>;

--- a/src/server/logs/connection-cache.ts
+++ b/src/server/logs/connection-cache.ts
@@ -1,0 +1,16 @@
+export function cachedConnection<T>(
+  key: string,
+  cache: Map<string, T> | undefined,
+  create: () => T,
+): T {
+  const existing = cache?.get(key);
+
+  if (existing) {
+    return existing;
+  }
+
+  const connection = create();
+  cache?.set(key, connection);
+
+  return connection;
+}

--- a/src/server/logs/csv/client-provider.ts
+++ b/src/server/logs/csv/client-provider.ts
@@ -1,14 +1,18 @@
 import * as fs from "fs";
 import * as path from "path";
 import { type TimeRange } from "~/lib/constants";
-import type { LogEntry, QueryLogsOptions, QueryLogsResult } from "../types";
-import { getTimeRangeConfig } from "../aggregation-utils";
-import { BaseMemoryLogProvider } from "../base-provider";
+import {
+  type LogEntry,
+  type QueryLogsOptions,
+  type QueryLogsResult,
+} from "~/server/logs/types";
+import { getTimeRangeConfig } from "~/server/logs/aggregation-utils";
+import { BaseMemoryLogProvider } from "~/server/logs/base-provider";
 import {
   streamAndParseEntries,
   createFilterFn,
   createTimeFilter,
-} from "./utils";
+} from "~/server/logs/csv/utils";
 
 const DATE_PATTERN = /^(\d{4}-\d{2}-\d{2})_.+\.log$/;
 

--- a/src/server/logs/csv/client-provider.ts
+++ b/src/server/logs/csv/client-provider.ts
@@ -1,19 +1,13 @@
 import * as fs from "fs";
 import * as path from "path";
 import { type TimeRange } from "~/lib/constants";
-import type {
-  LogEntry,
-  StatsResult,
-  QueryLogsOptions,
-  QueryLogsResult,
-} from "../types";
+import type { LogEntry, QueryLogsOptions, QueryLogsResult } from "../types";
 import { getTimeRangeConfig } from "../aggregation-utils";
 import { BaseMemoryLogProvider } from "../base-provider";
 import {
   streamAndParseEntries,
   createFilterFn,
   createTimeFilter,
-  computeStats,
 } from "./utils";
 
 const DATE_PATTERN = /^(\d{4}-\d{2}-\d{2})_.+\.log$/;
@@ -124,27 +118,8 @@ export class CsvClientLogProvider extends BaseMemoryLogProvider {
     };
   }
 
-  async getStats24h(): Promise<StatsResult> {
-    const logFiles = await this.findLatestDateFiles();
-    if (logFiles.length === 0) {
-      return { totalQueries: 0, blocked: 0 };
-    }
-
-    try {
-      const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
-      const filterFn = createTimeFilter(oneDayAgo);
-      const entriesArrays = await Promise.all(
-        logFiles.map((filePath) => streamAndParseEntries(filePath, filterFn)),
-      );
-      return computeStats(entriesArrays.flat());
-    } catch (error) {
-      console.error("Error getting stats:", error);
-      return { totalQueries: 0, blocked: 0 };
-    }
-  }
-
   protected async fetchEntriesInRange(range: TimeRange): Promise<LogEntry[]> {
-    const logFiles = await this.findLatestDateFiles();
+    const logFiles = await this.findLatestDateFiles({ throwOnError: true });
     if (logFiles.length === 0) return [];
 
     const { startTime } = getTimeRangeConfig(range);

--- a/src/server/logs/csv/provider.ts
+++ b/src/server/logs/csv/provider.ts
@@ -1,19 +1,13 @@
 import * as fs from "fs";
 import * as path from "path";
 import { type TimeRange } from "~/lib/constants";
-import type {
-  LogEntry,
-  StatsResult,
-  QueryLogsOptions,
-  QueryLogsResult,
-} from "../types";
+import type { LogEntry, QueryLogsOptions, QueryLogsResult } from "../types";
 import { getTimeRangeConfig } from "../aggregation-utils";
 import { BaseMemoryLogProvider } from "../base-provider";
 import {
   streamAndParseEntries,
   createFilterFn,
   createTimeFilter,
-  computeStats,
 } from "./utils";
 
 /**
@@ -87,7 +81,11 @@ export class CsvLogProvider extends BaseMemoryLogProvider {
   ): Promise<QueryLogsResult> {
     const filterFn = createFilterFn(options);
     const filteredEntries = await streamAndParseEntries(filePath, filterFn);
-    filteredEntries.reverse();
+    filteredEntries.sort(
+      (a, b) =>
+        new Date(b.requestTs ?? 0).getTime() -
+        new Date(a.requestTs ?? 0).getTime(),
+    );
 
     const totalCount = filteredEntries.length;
     const paginatedEntries = filteredEntries.slice(
@@ -101,27 +99,8 @@ export class CsvLogProvider extends BaseMemoryLogProvider {
     };
   }
 
-  async getStats24h(): Promise<StatsResult> {
-    const logFile = await this.findLatestLogFile();
-    if (!logFile) {
-      return { totalQueries: 0, blocked: 0 };
-    }
-
-    try {
-      const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
-      const entries = await streamAndParseEntries(
-        logFile,
-        createTimeFilter(oneDayAgo),
-      );
-      return computeStats(entries);
-    } catch (error) {
-      console.error("Error getting stats:", error);
-      return { totalQueries: 0, blocked: 0 };
-    }
-  }
-
   protected async fetchEntriesInRange(range: TimeRange): Promise<LogEntry[]> {
-    const logFile = await this.findLatestLogFile();
+    const logFile = await this.findLatestLogFile({ throwOnError: true });
     if (!logFile) return [];
 
     const { startTime } = getTimeRangeConfig(range);

--- a/src/server/logs/csv/provider.ts
+++ b/src/server/logs/csv/provider.ts
@@ -1,14 +1,18 @@
 import * as fs from "fs";
 import * as path from "path";
 import { type TimeRange } from "~/lib/constants";
-import type { LogEntry, QueryLogsOptions, QueryLogsResult } from "../types";
-import { getTimeRangeConfig } from "../aggregation-utils";
-import { BaseMemoryLogProvider } from "../base-provider";
+import {
+  type LogEntry,
+  type QueryLogsOptions,
+  type QueryLogsResult,
+} from "~/server/logs/types";
+import { getTimeRangeConfig } from "~/server/logs/aggregation-utils";
+import { BaseMemoryLogProvider } from "~/server/logs/base-provider";
 import {
   streamAndParseEntries,
   createFilterFn,
   createTimeFilter,
-} from "./utils";
+} from "~/server/logs/csv/utils";
 
 /**
  * CSV file-based log provider

--- a/src/server/logs/csv/utils.ts
+++ b/src/server/logs/csv/utils.ts
@@ -1,100 +1,81 @@
+import { isEntryInScope } from "~/server/logs/scope";
 import * as fs from "fs";
-import * as readline from "readline";
+import { pipeline } from "node:stream/promises";
+import { parse } from "csv-parse";
+import { z } from "zod";
 import type { LogEntry, QueryLogsOptions } from "../types";
 
-function parseLogLine(line: string): LogEntry | null {
-  try {
-    const trimmed = line.trim();
-    if (!trimmed) return null;
+const fieldsSchema = z.array(z.string()).min(11);
 
-    const fields = trimmed.split("\t");
+function parseLogFields(value: unknown): LogEntry | null {
+  const parsed = fieldsSchema.safeParse(value);
 
-    // Expected format: timestamp, clientIP, clientName, duration, reason, questionName, answer, responseCode, responseType, questionType, hostnameId
-    if (fields.length < 11) {
-      console.warn(
-        `Malformed log line (expected 11+ fields, got ${fields.length}):`,
-        line,
-      );
-      return null;
-    }
-
-    const parsedDuration = fields[3] ? parseInt(fields[3], 10) : NaN;
-
-    return {
-      requestTs: fields[0] || null,
-      clientIp: fields[1] || null,
-      clientName: fields[2] || null,
-      durationMs: Number.isNaN(parsedDuration) ? null : parsedDuration,
-      reason: fields[4] || null,
-      questionName: fields[5] || null,
-      answer: fields[6] || null,
-      responseCode: fields[7] || null,
-      responseType: fields[8] || null,
-      questionType: fields[9] || null,
-      hostname: fields[10] || null,
-      effectiveTldp: null,
-      id: null,
-    };
-  } catch (error) {
-    console.error(`Error parsing log line:`, error);
+  if (!parsed.success) {
     return null;
   }
+
+  const fields = parsed.data;
+  const parsedDuration = fields[3] ? parseInt(fields[3], 10) : NaN;
+
+  return {
+    requestTs: fields[0] || null,
+    clientIp: fields[1] || null,
+    clientName: fields[2] || null,
+    durationMs: Number.isNaN(parsedDuration) ? null : parsedDuration,
+    reason: fields[4] || null,
+    questionName: fields[5] || null,
+    answer: fields[6] || null,
+    responseCode: fields[7] || null,
+    responseType: fields[8] || null,
+    questionType: fields[9] || null,
+    hostname: fields[10] || null,
+    effectiveTldp: null,
+    id: null,
+  };
 }
 
-export function streamAndParseEntries(
+export async function streamAndParseEntries(
   filePath: string,
   filterFn?: (entry: LogEntry) => boolean,
 ): Promise<LogEntry[]> {
-  return new Promise((resolve, reject) => {
-    const entries: LogEntry[] = [];
-    let rejected = false;
+  const entries: LogEntry[] = [];
 
-    const stream = fs.createReadStream(filePath, {
-      encoding: "utf-8",
-      highWaterMark: 64 * 1024, // 64KB chunks
-    });
+  await pipeline(
+    fs.createReadStream(filePath, { highWaterMark: 64 * 1024 }),
+    parse({
+      delimiter: "\t",
+      relax_column_count: true,
+      relax_quotes: true,
+      skip_empty_lines: true,
+      skip_records_with_error: true,
+    }),
+    async (records: AsyncIterable<unknown>) => {
+      for await (const fields of records) {
+        const entry = parseLogFields(fields);
 
-    const rl = readline.createInterface({
-      input: stream,
-      crlfDelay: Infinity,
-    });
-
-    const onError = (error: Error) => {
-      if (rejected) return;
-      rejected = true;
-      reject(error);
-    };
-
-    rl.on("line", (line) => {
-      const entry = parseLogLine(line);
-      if (!entry) return;
-
-      if (!filterFn || filterFn(entry)) {
-        entries.push(entry);
+        if (entry && (!filterFn || filterFn(entry))) {
+          entries.push(entry);
+        }
       }
-    });
+    },
+  );
 
-    rl.on("close", () => {
-      if (!rejected) {
-        resolve(entries);
-      }
-    });
-
-    rl.on("error", onError);
-    stream.on("error", onError);
-  });
+  return entries;
 }
 
 export function createFilterFn(
   options: Pick<
     QueryLogsOptions,
-    "search" | "responseType" | "client" | "questionType"
+    "search" | "responseType" | "client" | "questionType" | "excludedHostnames"
   >,
 ): (entry: LogEntry) => boolean {
   const searchLower = options.search?.toLowerCase();
   const clientLower = options.client?.toLowerCase();
 
   return (entry: LogEntry): boolean => {
+    if (!isEntryInScope(entry, options)) {
+      return false;
+    }
     const passesSearch =
       !searchLower ||
       entry.questionName?.toLowerCase().includes(searchLower) === true;
@@ -113,15 +94,9 @@ export function createFilterFn(
 
 export function createTimeFilter(since: Date): (entry: LogEntry) => boolean {
   return (entry: LogEntry): boolean => {
-    if (!entry.requestTs) return false;
+    if (!entry.requestTs) {
+      return false;
+    }
     return new Date(entry.requestTs) >= since;
   };
-}
-
-export function computeStats(entries: LogEntry[]): {
-  totalQueries: number;
-  blocked: number;
-} {
-  const blocked = entries.filter((e) => e.responseType === "BLOCKED").length;
-  return { totalQueries: entries.length, blocked };
 }

--- a/src/server/logs/csv/utils.ts
+++ b/src/server/logs/csv/utils.ts
@@ -4,7 +4,7 @@ import * as fs from "fs";
 import { pipeline } from "node:stream/promises";
 import { parse } from "csv-parse";
 import { z } from "zod";
-import type { LogEntry, QueryLogsOptions } from "../types";
+import { type LogEntry, type QueryLogsOptions } from "~/server/logs/types";
 
 const fieldsSchema = z.array(z.string()).min(11);
 

--- a/src/server/logs/csv/utils.ts
+++ b/src/server/logs/csv/utils.ts
@@ -1,3 +1,4 @@
+import { normalizeLogTimestamp } from "~/server/logs/timestamp";
 import { isEntryInScope } from "~/server/logs/scope";
 import * as fs from "fs";
 import { pipeline } from "node:stream/promises";
@@ -18,7 +19,7 @@ function parseLogFields(value: unknown): LogEntry | null {
   const parsedDuration = fields[3] ? parseInt(fields[3], 10) : NaN;
 
   return {
-    requestTs: fields[0] || null,
+    requestTs: normalizeLogTimestamp(fields[0] || null, "local"),
     clientIp: fields[1] || null,
     clientName: fields[2] || null,
     durationMs: Number.isNaN(parsedDuration) ? null : parsedDuration,

--- a/src/server/logs/demo-provider.ts
+++ b/src/server/logs/demo-provider.ts
@@ -1,7 +1,8 @@
+import { isEntryInScope } from "~/server/logs/scope";
 import { type TimeRange } from "~/lib/constants";
 import type {
   LogEntry,
-  StatsResult,
+  LogScope,
   QueryLogsOptions,
   QueryLogsResult,
 } from "./types";
@@ -16,15 +17,17 @@ export class DemoLogProvider extends BaseMemoryLogProvider {
   async getQueryLogs(options: QueryLogsOptions): Promise<QueryLogsResult> {
     const { logEntryMock } = await import("~/mocks/logEntryMock");
 
-    let filteredLogs = logEntryMock.toSorted((item1, item2) => {
-      const date1 = new Date(item1.requestTs ?? 0);
-      const date2 = new Date(item2.requestTs ?? 0);
+    let filteredLogs = logEntryMock
+      .filter((entry) => isEntryInScope(entry, options))
+      .toSorted((item1, item2) => {
+        const date1 = new Date(item1.requestTs ?? 0);
+        const date2 = new Date(item2.requestTs ?? 0);
 
-      if (date1 > date2) return -1;
-      if (date1 < date2) return 1;
+        if (date1 > date2) return -1;
+        if (date1 < date2) return 1;
 
-      return 0;
-    });
+        return 0;
+      });
 
     if (options.search) {
       filteredLogs = filteredLogs.filter((log) =>
@@ -62,25 +65,6 @@ export class DemoLogProvider extends BaseMemoryLogProvider {
     };
   }
 
-  async getStats24h(): Promise<StatsResult> {
-    const { logEntryMock } = await import("~/mocks/logEntryMock");
-    const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
-
-    const recentLogs = logEntryMock.filter((log) => {
-      const logDate = new Date(log.requestTs ?? 0);
-      return logDate >= oneDayAgo;
-    });
-
-    const blocked = recentLogs.filter(
-      (log) => log.responseType === "BLOCKED",
-    ).length;
-
-    return {
-      totalQueries: recentLogs.length,
-      blocked,
-    };
-  }
-
   protected async fetchEntriesInRange(range: TimeRange): Promise<LogEntry[]> {
     const { logEntryMock } = await import("~/mocks/logEntryMock");
     const { startTime } = getTimeRangeConfig(range);
@@ -92,7 +76,11 @@ export class DemoLogProvider extends BaseMemoryLogProvider {
   }
 
   // Override to bypass caching - demo provider should always return fresh mock data
-  protected getEntriesInRange(range: TimeRange): Promise<LogEntry[]> {
-    return this.fetchEntriesInRange(range);
+  protected async getEntriesInRange(
+    range: TimeRange,
+    scope: LogScope = {},
+  ): Promise<LogEntry[]> {
+    const entries = await this.fetchEntriesInRange(range);
+    return entries.filter((entry) => isEntryInScope(entry, scope));
   }
 }

--- a/src/server/logs/demo-provider.ts
+++ b/src/server/logs/demo-provider.ts
@@ -1,13 +1,13 @@
 import { isEntryInScope } from "~/server/logs/scope";
 import { type TimeRange } from "~/lib/constants";
-import type {
-  LogEntry,
-  LogScope,
-  QueryLogsOptions,
-  QueryLogsResult,
-} from "./types";
-import { getTimeRangeConfig } from "./aggregation-utils";
-import { BaseMemoryLogProvider } from "./base-provider";
+import {
+  type LogEntry,
+  type LogScope,
+  type QueryLogsOptions,
+  type QueryLogsResult,
+} from "~/server/logs/types";
+import { getTimeRangeConfig } from "~/server/logs/aggregation-utils";
+import { BaseMemoryLogProvider } from "~/server/logs/base-provider";
 
 /**
  * Demo log provider that uses mock data.

--- a/src/server/logs/mysql/provider.ts
+++ b/src/server/logs/mysql/provider.ts
@@ -1,19 +1,32 @@
-import { sql, type SQL } from "drizzle-orm";
+import { desc, gte, inArray, sql, type SQL } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/mysql2";
 import { createPool } from "mysql2/promise";
 
+import { cachedConnection } from "~/server/logs/connection-cache";
 import { logEntries } from "~/server/logs/mysql/schema";
 import { type TimeRange } from "~/lib/constants";
 import { BaseSqlLogProvider } from "~/server/logs/sql/base-provider";
+import { type QueryLogsOptions } from "~/server/logs/types";
+
+const RECENT_SEARCH_ROWS = 65_536;
 
 export class MySQLLogProvider extends BaseSqlLogProvider {
   private readonly pool: ReturnType<typeof createPool>;
+  private readonly mysqlDb;
 
-  constructor(options: { connectionUri: string }) {
-    const pool = createPool({
-      uri: options.connectionUri,
-      timezone: "+00:00",
-    });
+  constructor(options: {
+    connectionUri: string;
+    connections?: Map<string, ReturnType<typeof createPool>>;
+  }) {
+    const pool = cachedConnection(
+      options.connectionUri,
+      options.connections,
+      () =>
+        createPool({
+          uri: options.connectionUri,
+          timezone: "+00:00",
+        }),
+    );
     const db = drizzle(pool, { schema: { logEntries }, mode: "default" });
 
     super({
@@ -23,6 +36,74 @@ export class MySQLLogProvider extends BaseSqlLogProvider {
     });
 
     this.pool = pool;
+    this.mysqlDb = db;
+  }
+
+  async getQueryLogRows(options: QueryLogsOptions) {
+    if (
+      !options.search ||
+      options.client ||
+      options.responseType ||
+      options.questionType
+    ) {
+      return super.getQueryLogRows(options);
+    }
+
+    if (options.offset + options.limit <= RECENT_SEARCH_ROWS) {
+      const [boundary] = await this.mysqlDb
+        .select({ timestamp: logEntries.requestTs })
+        .from(logEntries)
+        .orderBy(desc(logEntries.requestTs), desc(logEntries.id))
+        .offset(RECENT_SEARCH_ROWS - 1)
+        .limit(1);
+
+      if (!boundary) {
+        return super.getQueryLogRows(options);
+      }
+
+      if (boundary.timestamp) {
+        const recent = await this.readQueryLogRows(options, [
+          gte(logEntries.requestTs, boundary.timestamp),
+        ]);
+
+        if (recent.length === options.limit) {
+          return recent;
+        }
+      }
+    }
+
+    // Sparse matches make an ordered secondary-index scan read almost every full row.
+    return this.readQueryLogRows(options, [], { useIndex: ["PRIMARY"] });
+  }
+
+  protected async clientFilter(client: string): Promise<SQL> {
+    const clients = this.mysqlDb
+      .selectDistinct({ name: logEntries.clientName })
+      .from(logEntries)
+      .as("clients");
+    const matches = await this.mysqlDb
+      .select({ name: clients.name })
+      .from(clients)
+      .where(sql`LOWER(${clients.name}) LIKE LOWER(${`%${client}%`})`)
+      .limit(1001);
+
+    if (matches.length > 1000) {
+      return super.clientFilter(client);
+    }
+
+    const names = matches.flatMap(({ name }) => (name === null ? [] : [name]));
+
+    return names.length ? inArray(logEntries.clientName, names) : sql`false`;
+  }
+
+  protected getClientRankingIndexHints(
+    range: TimeRange,
+    filter: "all" | "blocked",
+  ) {
+    // Long-range client grouping otherwise favors repeated row lookups through the client-name index.
+    return filter === "all" && (range === "7d" || range === "30d")
+      ? { useIndex: ["PRIMARY"] }
+      : undefined;
   }
 
   async close(): Promise<void> {

--- a/src/server/logs/mysql/provider.ts
+++ b/src/server/logs/mysql/provider.ts
@@ -13,6 +13,7 @@ const RECENT_SEARCH_ROWS = 65_536;
 export class MySQLLogProvider extends BaseSqlLogProvider {
   private readonly pool: ReturnType<typeof createPool>;
   private readonly mysqlDb;
+  private readonly ownsConnection: boolean;
 
   constructor(options: {
     connectionUri: string;
@@ -36,6 +37,7 @@ export class MySQLLogProvider extends BaseSqlLogProvider {
     });
 
     this.pool = pool;
+    this.ownsConnection = !options.connections;
     this.mysqlDb = db;
   }
 
@@ -111,7 +113,9 @@ export class MySQLLogProvider extends BaseSqlLogProvider {
   }
 
   async close(): Promise<void> {
-    await this.pool.end();
+    if (this.ownsConnection) {
+      await this.pool.end();
+    }
   }
 
   protected getBucketExpression(range: TimeRange): SQL {

--- a/src/server/logs/mysql/provider.ts
+++ b/src/server/logs/mysql/provider.ts
@@ -76,6 +76,10 @@ export class MySQLLogProvider extends BaseSqlLogProvider {
     return this.readQueryLogRows(options, [], { useIndex: ["PRIMARY"] });
   }
 
+  protected hostnameExpression(): SQL {
+    return sql`CAST(${logEntries.hostname} AS BINARY)`;
+  }
+
   protected async clientFilter(client: string): Promise<SQL> {
     const clients = this.mysqlDb
       .selectDistinct({ name: logEntries.clientName })

--- a/src/server/logs/postgres/provider.ts
+++ b/src/server/logs/postgres/provider.ts
@@ -2,6 +2,7 @@ import { sql, type SQL } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 
+import { cachedConnection } from "~/server/logs/connection-cache";
 import { logEntries } from "~/server/logs/postgres/schema";
 import { type TimeRange } from "~/lib/constants";
 import { BaseSqlLogProvider } from "~/server/logs/sql/base-provider";
@@ -9,12 +10,20 @@ import { BaseSqlLogProvider } from "~/server/logs/sql/base-provider";
 export class PostgreSQLLogProvider extends BaseSqlLogProvider {
   private readonly conn: ReturnType<typeof postgres>;
 
-  constructor(options: { connectionUri: string }) {
-    const conn = postgres(options.connectionUri, {
-      connection: {
-        timezone: "UTC",
-      },
-    });
+  constructor(options: {
+    connectionUri: string;
+    connections?: Map<string, ReturnType<typeof postgres>>;
+  }) {
+    const conn = cachedConnection(
+      options.connectionUri,
+      options.connections,
+      () =>
+        postgres(options.connectionUri, {
+          connection: {
+            timezone: "UTC",
+          },
+        }),
+    );
     const db = drizzle(conn, { schema: { logEntries } });
 
     super({
@@ -28,6 +37,10 @@ export class PostgreSQLLogProvider extends BaseSqlLogProvider {
 
   async close(): Promise<void> {
     await this.conn.end();
+  }
+
+  protected queryLogTimestampOrder(): SQL {
+    return sql`${logEntries.requestTs} desc nulls last`;
   }
 
   protected formatDateTimeForFilter(date: Date): string {

--- a/src/server/logs/postgres/provider.ts
+++ b/src/server/logs/postgres/provider.ts
@@ -9,6 +9,7 @@ import { BaseSqlLogProvider } from "~/server/logs/sql/base-provider";
 
 export class PostgreSQLLogProvider extends BaseSqlLogProvider {
   private readonly conn: ReturnType<typeof postgres>;
+  private readonly ownsConnection: boolean;
 
   constructor(options: {
     connectionUri: string;
@@ -33,10 +34,13 @@ export class PostgreSQLLogProvider extends BaseSqlLogProvider {
     });
 
     this.conn = conn;
+    this.ownsConnection = !options.connections;
   }
 
   async close(): Promise<void> {
-    await this.conn.end();
+    if (this.ownsConnection) {
+      await this.conn.end();
+    }
   }
 
   protected queryLogTimestampOrder(): SQL {

--- a/src/server/logs/query-page.ts
+++ b/src/server/logs/query-page.ts
@@ -1,0 +1,12 @@
+import { type LogProvider, type QueryLogsOptions } from "~/server/logs/types";
+
+export async function readQueryLogPage(
+  provider: Pick<LogProvider, "getQueryLogRows" | "getQueryLogCount">,
+  options: QueryLogsOptions,
+) {
+  const [items, totalCount] = await Promise.all([
+    provider.getQueryLogRows(options),
+    provider.getQueryLogCount(options),
+  ]);
+  return { items, totalCount };
+}

--- a/src/server/logs/scope.ts
+++ b/src/server/logs/scope.ts
@@ -1,0 +1,5 @@
+import { type LogEntry, type LogScope } from "~/server/logs/types";
+
+export function isEntryInScope(entry: LogEntry, scope: LogScope): boolean {
+  return !entry.hostname || !scope.excludedHostnames?.includes(entry.hostname);
+}

--- a/src/server/logs/sql/base-provider.ts
+++ b/src/server/logs/sql/base-provider.ts
@@ -227,13 +227,17 @@ export abstract class BaseSqlLogProvider implements LogProvider {
     };
   }
 
+  protected hostnameExpression(): SQL {
+    return sql`${this.columns.hostname}`;
+  }
+
   private scopeFilters(scope: LogScope): SQL[] {
     if (!scope.excludedHostnames?.length) {
       return [];
     }
     const filter = or(
       isNull(this.columns.hostname),
-      notInArray(this.columns.hostname, scope.excludedHostnames),
+      notInArray(this.hostnameExpression(), scope.excludedHostnames),
     );
     return filter ? [filter] : [];
   }

--- a/src/server/logs/sql/base-provider.ts
+++ b/src/server/logs/sql/base-provider.ts
@@ -1,3 +1,9 @@
+import type {
+  StatsResult,
+  SearchDomainEntry,
+  SearchClientEntry,
+} from "~/server/logs/types";
+import { readQueryLogPage } from "~/server/logs/query-page";
 /**
  * Base class for SQL database log providers (MySQL, PostgreSQL, etc.)
  *
@@ -12,6 +18,11 @@ import {
   and,
   eq,
   gte,
+  lte,
+  or,
+  notInArray,
+  isNull,
+  inArray,
   type SQL,
   type Column,
 } from "drizzle-orm";
@@ -19,14 +30,13 @@ import { type TimeRange } from "~/lib/constants";
 import { getTimeRangeConfig } from "~/server/logs/aggregation-utils";
 import type {
   LogProvider,
+  LogScope,
+  QueryLogFilters,
   LogEntry,
-  StatsResult,
   QueriesOverTimeEntry,
   TopDomainEntry,
   TopClientEntry,
   QueryTypeEntry,
-  SearchDomainEntry,
-  SearchClientEntry,
   QueryLogsOptions,
   QueryLogsResult,
 } from "~/server/logs/types";
@@ -130,12 +140,15 @@ export abstract class BaseSqlLogProvider implements LogProvider {
     return column;
   }
 
-  private buildRangeFilters(options: {
-    range: TimeRange;
-    filter: "all" | "blocked";
-  }): SqlFilter[] {
+  private buildRangeFilters(
+    options: LogScope & {
+      range: TimeRange;
+      filter: "all" | "blocked";
+    },
+  ): SqlFilter[] {
     const { startTime } = getTimeRangeConfig(options.range);
     const filters: SqlFilter[] = [
+      ...this.scopeFilters(options),
       gte(this.columns.requestTs, this.formatDateTimeForFilter(startTime)),
     ];
 
@@ -214,8 +227,34 @@ export abstract class BaseSqlLogProvider implements LogProvider {
     };
   }
 
-  async getQueryLogs(options: QueryLogsOptions): Promise<QueryLogsResult> {
-    const filters = [];
+  private scopeFilters(scope: LogScope): SQL[] {
+    if (!scope.excludedHostnames?.length) {
+      return [];
+    }
+    const filter = or(
+      isNull(this.columns.hostname),
+      notInArray(this.columns.hostname, scope.excludedHostnames),
+    );
+    return filter ? [filter] : [];
+  }
+
+  protected async clientFilter(client: string): Promise<SQL> {
+    return sql`LOWER(${this.columns.clientName}) LIKE LOWER(${`%${client}%`})`;
+  }
+
+  protected getClientRankingIndexHints(
+    _range: TimeRange,
+    _filter: "all" | "blocked",
+  ): { useIndex: string[] } | undefined {
+    return undefined;
+  }
+
+  private async buildLogFilters(options: QueryLogFilters): Promise<SQL[]> {
+    const filters = this.scopeFilters(options);
+
+    if (options.maxId !== undefined && this.columns.id) {
+      filters.push(lte(this.columns.id, options.maxId));
+    }
 
     if (options.search) {
       filters.push(
@@ -228,20 +267,73 @@ export abstract class BaseSqlLogProvider implements LogProvider {
     }
 
     if (options.client) {
-      filters.push(
-        sql`LOWER(${this.columns.clientName}) LIKE LOWER(${`%${options.client}%`})`,
-      );
+      filters.push(await this.clientFilter(options.client));
     }
 
     if (options.questionType) {
       filters.push(eq(this.columns.questionType, options.questionType));
     }
 
-    const countQuery = this.db
+    return filters;
+  }
+
+  async getQueryLogCount(options: QueryLogFilters): Promise<number> {
+    const result = await this.db
       .select({ count: sql<number>`count(*)` })
       .from(this.table)
-      .where(filters.length > 0 ? and(...filters) : undefined);
+      .where(and(...(await this.buildLogFilters(options))));
+    return Number(result[0]?.count ?? 0);
+  }
 
+  async getQueryLogSnapshot() {
+    if (!this.columns.id) {
+      return undefined;
+    }
+
+    const result = await this.db
+      .select({ id: sql<number>`max(${this.columns.id})` })
+      .from(this.table);
+
+    return Number(result[0]?.id ?? 0);
+  }
+
+  async getQueryLogCountSince(
+    options: QueryLogFilters,
+    since: Date,
+  ): Promise<number> {
+    const timestamp = gte(
+      this.columns.requestTs,
+      this.formatDateTimeForFilter(since),
+    );
+    const result = await this.db
+      .select({ count: sql<number>`count(*)` })
+      .from(this.table)
+      .where(
+        and(
+          ...(await this.buildLogFilters(options)),
+          since.getTime() <= 0
+            ? or(timestamp, isNull(this.columns.requestTs))
+            : timestamp,
+        ),
+      );
+
+    return Number(result[0]?.count ?? 0);
+  }
+
+  getQueryLogRows(options: QueryLogsOptions): Promise<LogEntry[]> {
+    return this.readQueryLogRows(options);
+  }
+
+  protected queryLogTimestampOrder(): SQL {
+    return desc(this.columns.requestTs);
+  }
+
+  protected async readQueryLogRows(
+    options: QueryLogsOptions,
+    extraFilters: SQL[] = [],
+    indexHints?: { useIndex: string[] },
+  ): Promise<LogEntry[]> {
+    const filters = [...(await this.buildLogFilters(options)), ...extraFilters];
     const selectFields: Record<string, Column | SQL> = {
       requestTs: this.columns.requestTs,
       clientIp: this.columns.clientIp,
@@ -262,53 +354,65 @@ export abstract class BaseSqlLogProvider implements LogProvider {
       selectFields.id = this.columns.id;
     }
 
+    const order = [
+      this.queryLogTimestampOrder(),
+      ...(this.columns.id
+        ? [desc(this.columns.id)]
+        : [
+            asc(this.columns.questionName),
+            asc(this.columns.clientIp),
+            asc(this.columns.questionType),
+            asc(this.columns.responseType),
+            asc(this.columns.answer),
+          ]),
+    ];
+    const seekById = options.offset > 0 && this.columns.id;
     const query = this.db
-      .select(selectFields)
-      .from(this.table)
-      .orderBy(desc(this.columns.requestTs))
+      .select(seekById ? { id: seekById } : selectFields)
+      .from(this.table, indexHints)
+      .orderBy(...order)
       .limit(options.limit)
       .offset(options.offset)
       .where(filters.length > 0 ? and(...filters) : undefined);
 
-    const [countResult, rows] = await Promise.all([countQuery, query]);
-    const count = countResult?.[0]?.count ?? 0;
+    let rows = await query;
 
-    return {
-      items: rows.map((row: Record<string, unknown>) =>
-        this.mapRowToLogEntry(row),
-      ),
-      totalCount: Number(count),
-    };
+    if (seekById && rows.length > 0) {
+      rows = await this.db
+        .select(selectFields)
+        .from(this.table)
+        .where(
+          and(
+            ...filters,
+            inArray(
+              seekById,
+              rows.map((row: Record<string, unknown>) => Number(row.id)),
+            ),
+          ),
+        )
+        .orderBy(...order);
+    }
+    return rows.map((row: Record<string, unknown>) =>
+      this.mapRowToLogEntry(row),
+    );
   }
 
-  async getStats24h(): Promise<StatsResult> {
-    const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
-
-    const result = await this.db
-      .select({
-        totalQueries: sql<number>`count(*)`,
-        blocked: sql<number>`sum(case when ${this.columns.responseType} = 'BLOCKED' then 1 else 0 end)`,
-      })
-      .from(this.table)
-      .where(
-        gte(this.columns.requestTs, this.formatDateTimeForFilter(oneDayAgo)),
-      );
-
-    return {
-      totalQueries: Number(result[0]?.totalQueries ?? 0),
-      blocked: Number(result[0]?.blocked ?? 0),
-    };
+  getQueryLogs(options: QueryLogsOptions): Promise<QueryLogsResult> {
+    return readQueryLogPage(this, options);
   }
 
-  async getQueriesOverTime(options: {
-    range: TimeRange;
-    domain?: string;
-    client?: string;
-  }): Promise<QueriesOverTimeEntry[]> {
+  async getQueriesOverTime(
+    options: LogScope & {
+      range: TimeRange;
+      domain?: string;
+      client?: string;
+    },
+  ): Promise<QueriesOverTimeEntry[]> {
     const { startTime, interval } = getTimeRangeConfig(options.range);
     const bucketExpr = this.getBucketExpression(options.range);
 
     const filters = [
+      ...this.scopeFilters(options),
       gte(this.columns.requestTs, this.formatDateTimeForFilter(startTime)),
     ];
 
@@ -339,15 +443,17 @@ export abstract class BaseSqlLogProvider implements LogProvider {
     return fillTimeBuckets(result, startTime, interval, options.range);
   }
 
-  async getTopDomains(options: {
-    range: TimeRange;
-    limit: number;
-    offset: number;
-    filter: "all" | "blocked";
-  }): Promise<{ items: TopDomainEntry[]; totalCount: number }> {
+  async getTopDomains(
+    options: LogScope & {
+      range: TimeRange;
+      limit?: number;
+      offset: number;
+      filter: "all" | "blocked";
+    },
+  ): Promise<{ items: TopDomainEntry[]; totalCount: number }> {
     const filters = this.buildRangeFilters(options);
 
-    const result = await this.db
+    const query = this.db
       .select({
         domain: this.columns.questionName,
         count: sql<number>`count(*)`,
@@ -362,9 +468,10 @@ export abstract class BaseSqlLogProvider implements LogProvider {
         desc(sql`count(*)`),
         asc(this.getTextSortExpression(this.columns.questionName)),
         asc(this.columns.questionName),
-      )
-      .limit(options.limit)
-      .offset(options.offset);
+      );
+    const result = await (options.limit === undefined
+      ? query
+      : query.limit(options.limit).offset(options.offset));
 
     const { totalQueriesCount, totalCount } = await this.resolveGroupedTotals({
       row: result[0],
@@ -387,15 +494,17 @@ export abstract class BaseSqlLogProvider implements LogProvider {
     };
   }
 
-  async getTopClients(options: {
-    range: TimeRange;
-    limit: number;
-    offset: number;
-    filter: "all" | "blocked";
-  }): Promise<{ items: TopClientEntry[]; totalCount: number }> {
+  async getTopClients(
+    options: LogScope & {
+      range: TimeRange;
+      limit?: number;
+      offset: number;
+      filter: "all" | "blocked";
+    },
+  ): Promise<{ items: TopClientEntry[]; totalCount: number }> {
     const filters = this.buildRangeFilters(options);
 
-    const result = await this.db
+    const query = this.db
       .select({
         client: this.columns.clientName,
         total: sql<number>`count(*)`,
@@ -403,16 +512,20 @@ export abstract class BaseSqlLogProvider implements LogProvider {
         totalCount: sql<number>`count(*) over ()`,
         totalQueriesCount: sql<number>`sum(count(*)) over ()`,
       })
-      .from(this.table)
+      .from(
+        this.table,
+        this.getClientRankingIndexHints(options.range, options.filter),
+      )
       .where(and(...filters))
       .groupBy(this.columns.clientName)
       .orderBy(
         desc(sql`count(*)`),
         asc(this.getTextSortExpression(this.columns.clientName)),
         asc(this.columns.clientName),
-      )
-      .limit(options.limit)
-      .offset(options.offset);
+      );
+    const result = await (options.limit === undefined
+      ? query
+      : query.limit(options.limit).offset(options.offset));
 
     const { totalQueriesCount, totalCount } = await this.resolveGroupedTotals({
       row: result[0],
@@ -435,14 +548,20 @@ export abstract class BaseSqlLogProvider implements LogProvider {
     };
   }
 
-  async getQueryTypesBreakdown(range: TimeRange): Promise<QueryTypeEntry[]> {
+  async getQueryTypesBreakdown(
+    range: TimeRange,
+    scope: LogScope = {},
+  ): Promise<QueryTypeEntry[]> {
     const { startTime } = getTimeRangeConfig(range);
 
     const totalResult = await this.db
       .select({ count: sql<number>`count(*)` })
       .from(this.table)
       .where(
-        gte(this.columns.requestTs, this.formatDateTimeForFilter(startTime)),
+        and(
+          gte(this.columns.requestTs, this.formatDateTimeForFilter(startTime)),
+          ...this.scopeFilters(scope),
+        ),
       );
     const totalCount = Number(totalResult[0]?.count ?? 0);
 
@@ -453,7 +572,10 @@ export abstract class BaseSqlLogProvider implements LogProvider {
       })
       .from(this.table)
       .where(
-        gte(this.columns.requestTs, this.formatDateTimeForFilter(startTime)),
+        and(
+          gte(this.columns.requestTs, this.formatDateTimeForFilter(startTime)),
+          ...this.scopeFilters(scope),
+        ),
       )
       .groupBy(this.columns.questionType)
       .orderBy(
@@ -467,6 +589,25 @@ export abstract class BaseSqlLogProvider implements LogProvider {
       count: Number(row.count),
       percentage: totalCount > 0 ? (Number(row.count) / totalCount) * 100 : 0,
     }));
+  }
+
+  async getStats24h(): Promise<StatsResult> {
+    const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
+
+    const result = await this.db
+      .select({
+        totalQueries: sql<number>`count(*)`,
+        blocked: sql<number>`sum(case when ${this.columns.responseType} = 'BLOCKED' then 1 else 0 end)`,
+      })
+      .from(this.table)
+      .where(
+        gte(this.columns.requestTs, this.formatDateTimeForFilter(oneDayAgo)),
+      );
+
+    return {
+      totalQueries: Number(result[0]?.totalQueries ?? 0),
+      blocked: Number(result[0]?.blocked ?? 0),
+    };
   }
 
   async searchDomains(options: {
@@ -561,7 +702,7 @@ function fillTimeBuckets(
   const dataMap = new Map(data.map((d) => [d.timeBucket, d]));
   const results: QueriesOverTimeEntry[] = [];
   const now = Date.now();
-  let current = startTime.getTime();
+  let current = Math.floor(startTime.getTime() / interval) * interval;
 
   while (current <= now) {
     const date = new Date(current);

--- a/src/server/logs/sql/base-provider.ts
+++ b/src/server/logs/sql/base-provider.ts
@@ -1,7 +1,7 @@
-import type {
-  StatsResult,
-  SearchDomainEntry,
-  SearchClientEntry,
+import {
+  type StatsResult,
+  type SearchDomainEntry,
+  type SearchClientEntry,
 } from "~/server/logs/types";
 import { readQueryLogPage } from "~/server/logs/query-page";
 /**
@@ -28,17 +28,17 @@ import {
 } from "drizzle-orm";
 import { type TimeRange } from "~/lib/constants";
 import { getTimeRangeConfig } from "~/server/logs/aggregation-utils";
-import type {
-  LogProvider,
-  LogScope,
-  QueryLogFilters,
-  LogEntry,
-  QueriesOverTimeEntry,
-  TopDomainEntry,
-  TopClientEntry,
-  QueryTypeEntry,
-  QueryLogsOptions,
-  QueryLogsResult,
+import {
+  type LogProvider,
+  type LogScope,
+  type QueryLogFilters,
+  type LogEntry,
+  type QueriesOverTimeEntry,
+  type TopDomainEntry,
+  type TopClientEntry,
+  type QueryTypeEntry,
+  type QueryLogsOptions,
+  type QueryLogsResult,
 } from "~/server/logs/types";
 
 /**

--- a/src/server/logs/sqlite/provider.ts
+++ b/src/server/logs/sqlite/provider.ts
@@ -9,6 +9,7 @@ import { logEntries } from "~/server/logs/sqlite/schema";
 
 export class SQLiteLogProvider extends BaseSqlLogProvider {
   private readonly dbFile: Database.Database;
+  private readonly ownsConnection: boolean;
 
   constructor(options: {
     filePath: string;
@@ -34,10 +35,13 @@ export class SQLiteLogProvider extends BaseSqlLogProvider {
     });
 
     this.dbFile = dbFile;
+    this.ownsConnection = !options.connections;
   }
 
   async close(): Promise<void> {
-    this.dbFile.close();
+    if (this.ownsConnection) {
+      this.dbFile.close();
+    }
   }
 
   protected getTextSortExpression(column: Column): SQL {

--- a/src/server/logs/sqlite/provider.ts
+++ b/src/server/logs/sqlite/provider.ts
@@ -2,6 +2,7 @@ import { sql, type Column, type SQL } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import Database from "better-sqlite3";
 
+import { cachedConnection } from "~/server/logs/connection-cache";
 import { type TimeRange } from "~/lib/constants";
 import { BaseSqlLogProvider } from "~/server/logs/sql/base-provider";
 import { logEntries } from "~/server/logs/sqlite/schema";
@@ -9,11 +10,19 @@ import { logEntries } from "~/server/logs/sqlite/schema";
 export class SQLiteLogProvider extends BaseSqlLogProvider {
   private readonly dbFile: Database.Database;
 
-  constructor(options: { filePath: string }) {
-    const dbFile = new Database(options.filePath, {
-      readonly: true,
-      fileMustExist: true,
-    });
+  constructor(options: {
+    filePath: string;
+    connections?: Map<string, Database.Database>;
+  }) {
+    const dbFile = cachedConnection(
+      options.filePath,
+      options.connections,
+      () =>
+        new Database(options.filePath, {
+          readonly: true,
+          fileMustExist: true,
+        }),
+    );
     dbFile.pragma("busy_timeout = 5000");
 
     const db = drizzle(dbFile, { schema: { logEntries } });

--- a/src/server/logs/timestamp.test.ts
+++ b/src/server/logs/timestamp.test.ts
@@ -1,0 +1,16 @@
+import { expect, it } from "vitest";
+import { normalizeLogTimestamp } from "~/server/logs/timestamp";
+
+it.each([
+  ["2026-09-05 12:30:00.100", "2026-09-05T12:30:00.100Z"],
+  ["2026-09-05 12:30:00.1+00", "2026-09-05T12:30:00.100Z"],
+  ["2026-09-05T14:30:00.1+02:00", "2026-09-05T12:30:00.100Z"],
+  ["2026-09-05T12:30:00Z", "2026-09-05T12:30:00.000Z"],
+  [null, null],
+  ["invalid", null],
+])(
+  "normalizes timestamps independently of the dashboard host timezone",
+  (input, expected) => {
+    expect(normalizeLogTimestamp(input)).toBe(expected);
+  },
+);

--- a/src/server/logs/timestamp.test.ts
+++ b/src/server/logs/timestamp.test.ts
@@ -14,3 +14,14 @@ it.each([
     expect(normalizeLogTimestamp(input)).toBe(expected);
   },
 );
+
+it("preserves local wall-clock interpretation for timezone-less CSV dates", () => {
+  const value = "2026-09-05 12:30:00.100";
+
+  expect(normalizeLogTimestamp(value, "local")).toBe(
+    new Date(value).toISOString(),
+  );
+  expect(normalizeLogTimestamp("2026-09-05T14:30:00+02:00", "local")).toBe(
+    "2026-09-05T12:30:00.000Z",
+  );
+});

--- a/src/server/logs/timestamp.ts
+++ b/src/server/logs/timestamp.ts
@@ -1,11 +1,14 @@
-export function normalizeLogTimestamp(value: string | null): string | null {
+export function normalizeLogTimestamp(
+  value: string | null,
+  timezone: "utc" | "local" = "utc",
+): string | null {
   if (!value) {
     return null;
   }
   let normalized = value.replace(" ", "T");
   if (/[+-]\d{2}$/.test(normalized)) {
     normalized += ":00";
-  } else if (!/(Z|[+-]\d{2}:?\d{2})$/i.test(normalized)) {
+  } else if (timezone === "utc" && !/(Z|[+-]\d{2}:?\d{2})$/i.test(normalized)) {
     normalized += "Z";
   }
   const time = Date.parse(normalized);

--- a/src/server/logs/timestamp.ts
+++ b/src/server/logs/timestamp.ts
@@ -1,0 +1,13 @@
+export function normalizeLogTimestamp(value: string | null): string | null {
+  if (!value) {
+    return null;
+  }
+  let normalized = value.replace(" ", "T");
+  if (/[+-]\d{2}$/.test(normalized)) {
+    normalized += ":00";
+  } else if (!/(Z|[+-]\d{2}:?\d{2})$/i.test(normalized)) {
+    normalized += "Z";
+  }
+  const time = Date.parse(normalized);
+  return Number.isFinite(time) ? new Date(time).toISOString() : null;
+}

--- a/src/server/logs/types.ts
+++ b/src/server/logs/types.ts
@@ -17,11 +17,6 @@ export interface LogEntry {
   id?: number | null;
 }
 
-export interface StatsResult {
-  totalQueries: number;
-  blocked: number;
-}
-
 export interface QueriesOverTimeEntry {
   time: string;
   total: number;
@@ -49,23 +44,21 @@ export interface QueryTypeEntry {
   percentage: number;
 }
 
-export interface SearchDomainEntry {
-  domain: string;
-  count: number;
+export interface LogScope {
+  excludedHostnames?: string[];
 }
 
-export interface SearchClientEntry {
-  client: string;
-  count: number;
-}
-
-export interface QueryLogsOptions {
-  limit: number;
-  offset: number;
+export interface QueryLogFilters extends LogScope {
+  maxId?: number;
   search?: string;
   responseType?: string;
   client?: string;
   questionType?: string;
+}
+
+export interface QueryLogsOptions extends QueryLogFilters {
+  limit: number;
+  offset: number;
 }
 
 export interface QueryLogsResult {
@@ -78,29 +71,49 @@ export interface LogProvider {
 
   getQueryLogs(options: QueryLogsOptions): Promise<QueryLogsResult>;
 
+  getQueryLogRows(options: QueryLogsOptions): Promise<LogEntry[]>;
+
+  getQueryLogCount(options: QueryLogFilters): Promise<number>;
+
+  getQueryLogSnapshot?(): Promise<number | undefined>;
+
+  getQueryLogCountSince?(
+    options: QueryLogFilters,
+    since: Date,
+  ): Promise<number>;
+
+  getQueriesOverTime(
+    options: LogScope & {
+      range: TimeRange;
+      domain?: string;
+      client?: string;
+    },
+  ): Promise<QueriesOverTimeEntry[]>;
+
+  getTopDomains(
+    options: LogScope & {
+      range: TimeRange;
+      limit?: number;
+      offset: number;
+      filter: "all" | "blocked";
+    },
+  ): Promise<{ items: TopDomainEntry[]; totalCount: number }>;
+
+  getTopClients(
+    options: LogScope & {
+      range: TimeRange;
+      limit?: number;
+      offset: number;
+      filter: "all" | "blocked";
+    },
+  ): Promise<{ items: TopClientEntry[]; totalCount: number }>;
+
+  getQueryTypesBreakdown(
+    range: TimeRange,
+    scope?: LogScope,
+  ): Promise<QueryTypeEntry[]>;
+
   getStats24h(): Promise<StatsResult>;
-
-  getQueriesOverTime(options: {
-    range: TimeRange;
-    domain?: string;
-    client?: string;
-  }): Promise<QueriesOverTimeEntry[]>;
-
-  getTopDomains(options: {
-    range: TimeRange;
-    limit: number;
-    offset: number;
-    filter: "all" | "blocked";
-  }): Promise<{ items: TopDomainEntry[]; totalCount: number }>;
-
-  getTopClients(options: {
-    range: TimeRange;
-    limit: number;
-    offset: number;
-    filter: "all" | "blocked";
-  }): Promise<{ items: TopClientEntry[]; totalCount: number }>;
-
-  getQueryTypesBreakdown(range: TimeRange): Promise<QueryTypeEntry[]>;
 
   searchDomains(options: {
     range: TimeRange;
@@ -113,4 +126,19 @@ export interface LogProvider {
     query: string;
     limit: number;
   }): Promise<SearchClientEntry[]>;
+}
+
+export interface StatsResult {
+  totalQueries: number;
+  blocked: number;
+}
+
+export interface SearchDomainEntry {
+  domain: string;
+  count: number;
+}
+
+export interface SearchClientEntry {
+  client: string;
+  count: number;
 }

--- a/src/server/logs/victorialogs/provider.ts
+++ b/src/server/logs/victorialogs/provider.ts
@@ -421,8 +421,6 @@ export class VictoriaLogsProvider implements LogProvider {
   }
 
   async getStats24h(): Promise<StatsResult> {
-    // VictoriaLogs does not support conditional aggregation (count(if(...))),
-    // so total and blocked counts require separate queries.
     const [totalResult, blockedResult] = await Promise.all([
       this.queryRaw(`${BASE_FILTER} | stats count() as total`, {
         start: "24h",

--- a/src/server/logs/victorialogs/provider.ts
+++ b/src/server/logs/victorialogs/provider.ts
@@ -1,15 +1,20 @@
+import {
+  type SearchClientEntry,
+  type SearchDomainEntry,
+  type StatsResult,
+} from "~/server/logs/types";
+import { readQueryLogPage } from "~/server/logs/query-page";
 import ky from "ky";
 import { getTimeRangeConfig } from "~/server/logs/aggregation-utils";
 import {
   type LogEntry,
+  type LogScope,
+  type QueryLogFilters,
   type LogProvider,
   type QueriesOverTimeEntry,
   type QueryLogsOptions,
   type QueryLogsResult,
   type QueryTypeEntry,
-  type SearchClientEntry,
-  type SearchDomainEntry,
-  type StatsResult,
   type TopClientEntry,
   type TopDomainEntry,
 } from "~/server/logs/types";
@@ -37,17 +42,12 @@ function rangeToVlBucket(range: TimeRange): string {
   }
 }
 
-// Escape user input for use inside a VL field:~"..." regex filter.
-// VictoriaLogs does not support backslash escape sequences inside its
-// double-quoted regex strings — e.g. \. causes a parse error when users
-// filter by IP address. Use RE2 bracket expressions ([.], [*], etc.) so
-// that no backslash characters appear in the produced pattern.
-// " is escaped as ["] to prevent closing the surrounding string literal.
-// [ is escaped as [[] (RE2 character class containing [).
-// ] and \ are left unescaped; they are never present in DNS names or IPs
-// and a stray ] or \ produces a benign regex error rather than injection.
-function escapeRegex(s: string): string {
-  return s.replace(/["[.+*?^${}()|]/g, (c) => (c === "[" ? "[[]" : `[${c}]`));
+function regexFilter(
+  field: "question_name" | "client_names",
+  value: string,
+): string {
+  const pattern = value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return `${field}:~${JSON.stringify(`(?i)${pattern}`)}`;
 }
 
 // Normalise a VL timestamp to a consistent key format for bucket lookups.
@@ -104,7 +104,9 @@ export class VictoriaLogsProvider implements LogProvider {
   ): Promise<Record<string, string>[]> {
     try {
       const searchParams = new URLSearchParams({ query: logql });
-      if (params.start) searchParams.set("start", params.start);
+      if (params.start) {
+        searchParams.set("start", params.start);
+      }
       if (params.limit !== undefined)
         searchParams.set("limit", String(params.limit));
 
@@ -139,69 +141,76 @@ export class VictoriaLogsProvider implements LogProvider {
       responseCode: raw.response_code || null,
       responseType: raw.response_type || null,
       questionType: raw.question_type || null,
-      hostname: null,
+      hostname: raw.instance || null,
       effectiveTldp: null,
       id: null,
     };
   }
 
-  async getQueryLogs(options: QueryLogsOptions): Promise<QueryLogsResult> {
-    const { limit, offset, search, responseType, client, questionType } =
-      options;
-
-    const filters = [BASE_FILTER];
-    if (responseType) filters.push(`response_type:${responseType}`);
-    if (client) filters.push(`client_names:~"(?i)${escapeRegex(client)}"`);
-    if (questionType) filters.push(`question_type:${questionType}`);
-    if (search) filters.push(`question_name:~"(?i)${escapeRegex(search)}"`);
-
-    const baseQuery = filters.join(" AND ");
-
-    const [entries, countResult] = await Promise.all([
-      this.queryRaw(
-        `${baseQuery} | sort by (_time desc, question_name asc) | offset ${offset} | limit ${limit}`,
+  private scopeQuery(scope: LogScope): string {
+    return [
+      BASE_FILTER,
+      ...(scope.excludedHostnames ?? []).map(
+        (hostname) => `NOT instance:exact(${JSON.stringify(hostname)})`,
       ),
-      this.queryRaw(`${baseQuery} | stats count() as total`),
-    ]);
-
-    return {
-      items: entries.map((r) => this.mapEntry(r)),
-      totalCount: Number(countResult[0]?.total ?? 0),
-    };
+    ].join(" AND ");
   }
 
-  async getStats24h(): Promise<StatsResult> {
-    // VictoriaLogs does not support conditional aggregation (count(if(...))),
-    // so total and blocked counts require separate queries.
-    const [totalResult, blockedResult] = await Promise.all([
-      this.queryRaw(`${BASE_FILTER} | stats count() as total`, {
-        start: "24h",
-      }),
-      this.queryRaw(
-        `${BASE_FILTER} AND response_type:BLOCKED | stats count() as blocked`,
-        { start: "24h" },
-      ),
-    ]);
-
-    return {
-      totalQueries: Number(totalResult[0]?.total ?? 0),
-      blocked: Number(blockedResult[0]?.blocked ?? 0),
-    };
+  private logQuery(options: QueryLogFilters): string {
+    const { search, responseType, client, questionType } = options;
+    const filters = [this.scopeQuery(options)];
+    if (responseType) {
+      filters.push(`response_type:exact(${JSON.stringify(responseType)})`);
+    }
+    if (client) {
+      filters.push(regexFilter("client_names", client));
+    }
+    if (questionType) {
+      filters.push(`question_type:exact(${JSON.stringify(questionType)})`);
+    }
+    if (search) {
+      filters.push(regexFilter("question_name", search));
+    }
+    return filters.join(" AND ");
   }
 
-  async getQueriesOverTime(options: {
-    range: TimeRange;
-    domain?: string;
-    client?: string;
-  }): Promise<QueriesOverTimeEntry[]> {
+  async getQueryLogRows(options: QueryLogsOptions): Promise<LogEntry[]> {
+    const entries = await this.queryRaw(
+      `${this.logQuery(options)} | sort by (_time desc, question_name asc, client_ip asc, question_type asc, response_type asc, answer asc, instance asc) | offset ${options.offset} | limit ${options.limit}`,
+    );
+    return entries.map((entry) => this.mapEntry(entry));
+  }
+
+  async getQueryLogCount(options: QueryLogFilters): Promise<number> {
+    const result = await this.queryRaw(
+      `${this.logQuery(options)} | stats count() as total`,
+    );
+    return Number(result[0]?.total ?? 0);
+  }
+
+  getQueryLogs(options: QueryLogsOptions): Promise<QueryLogsResult> {
+    return readQueryLogPage(this, options);
+  }
+
+  async getQueriesOverTime(
+    options: LogScope & {
+      range: TimeRange;
+      domain?: string;
+      client?: string;
+    },
+  ): Promise<QueriesOverTimeEntry[]> {
     const { range, domain, client } = options;
     const { startTime, interval } = getTimeRangeConfig(range);
     const start = startTime.toISOString();
     const bucket = rangeToVlBucket(range);
 
-    const filters = [BASE_FILTER];
-    if (domain) filters.push(`question_name:~"(?i)${escapeRegex(domain)}"`);
-    if (client) filters.push(`client_names:~"(?i)${escapeRegex(client)}"`);
+    const filters = [this.scopeQuery(options)];
+    if (domain) {
+      filters.push(regexFilter("question_name", domain));
+    }
+    if (client) {
+      filters.push(regexFilter("client_names", client));
+    }
     const base = filters.join(" AND ");
 
     const [totalRows, blockedRows, cachedRows] = await Promise.all([
@@ -253,22 +262,41 @@ export class VictoriaLogsProvider implements LogProvider {
     );
   }
 
-  async getTopDomains(options: {
-    range: TimeRange;
-    limit: number;
-    offset: number;
-    filter: "all" | "blocked";
-  }): Promise<{ items: TopDomainEntry[]; totalCount: number }> {
-    const { range, limit, offset, filter } = options;
+  private rankedQuery(
+    options: LogScope & {
+      filter: "all" | "blocked";
+      limit?: number;
+      offset: number;
+    },
+  ) {
+    const base = this.scopeQuery(options);
+    return {
+      base:
+        options.filter === "blocked"
+          ? `${base} AND response_type:BLOCKED`
+          : base,
+      pagination:
+        options.limit === undefined
+          ? ""
+          : `| offset ${options.offset} | limit ${options.limit}`,
+    };
+  }
+
+  async getTopDomains(
+    options: LogScope & {
+      range: TimeRange;
+      limit?: number;
+      offset: number;
+      filter: "all" | "blocked";
+    },
+  ): Promise<{ items: TopDomainEntry[]; totalCount: number }> {
+    const { range, filter } = options;
     const start = rangeToVlStart(range);
-    const base =
-      filter === "blocked"
-        ? `${BASE_FILTER} AND response_type:BLOCKED`
-        : BASE_FILTER;
+    const { base, pagination } = this.rankedQuery(options);
 
     const [dataRows, countResult, totalQueriesResult] = await Promise.all([
       this.queryRaw(
-        `${base} | stats by (question_name) count() as count | format "<lc:question_name>" as __qname_sort | sort by (count desc, __qname_sort asc) | offset ${offset} | limit ${limit}`,
+        `${base} | stats by (question_name) count() as count | format "<lc:question_name>" as __qname_sort | sort by (count desc, __qname_sort asc) ${pagination}`,
         { start },
       ),
       // Number of distinct domains (for pagination totalCount).
@@ -298,7 +326,7 @@ export class VictoriaLogsProvider implements LogProvider {
 
     if (filter === "all" && items.length > 0) {
       const blockedRows = await this.queryRaw(
-        `${BASE_FILTER} AND response_type:BLOCKED | stats by (question_name) count() as blocked`,
+        `${this.scopeQuery(options)} AND response_type:BLOCKED | stats by (question_name) count() as blocked`,
         { start },
       );
       const blockedByDomain = new Map(
@@ -315,22 +343,21 @@ export class VictoriaLogsProvider implements LogProvider {
     return { items, totalCount };
   }
 
-  async getTopClients(options: {
-    range: TimeRange;
-    limit: number;
-    offset: number;
-    filter: "all" | "blocked";
-  }): Promise<{ items: TopClientEntry[]; totalCount: number }> {
-    const { range, limit, offset, filter } = options;
+  async getTopClients(
+    options: LogScope & {
+      range: TimeRange;
+      limit?: number;
+      offset: number;
+      filter: "all" | "blocked";
+    },
+  ): Promise<{ items: TopClientEntry[]; totalCount: number }> {
+    const { range, filter } = options;
     const start = rangeToVlStart(range);
-    const base =
-      filter === "blocked"
-        ? `${BASE_FILTER} AND response_type:BLOCKED`
-        : BASE_FILTER;
+    const { base, pagination } = this.rankedQuery(options);
 
     const [dataRows, countResult, totalQueriesResult] = await Promise.all([
       this.queryRaw(
-        `${base} | stats by (client_names) count() as total | format "<lc:client_names>" as __client_sort | sort by (total desc, __client_sort asc) | offset ${offset} | limit ${limit}`,
+        `${base} | stats by (client_names) count() as total | format "<lc:client_names>" as __client_sort | sort by (total desc, __client_sort asc) ${pagination}`,
         { start },
       ),
       // Same chained-stats pattern as getTopDomains for null-entry inclusion.
@@ -357,7 +384,7 @@ export class VictoriaLogsProvider implements LogProvider {
 
     if (filter === "all" && items.length > 0) {
       const blockedRows = await this.queryRaw(
-        `${BASE_FILTER} AND response_type:BLOCKED | stats by (client_names) count() as blocked`,
+        `${this.scopeQuery(options)} AND response_type:BLOCKED | stats by (client_names) count() as blocked`,
         { start },
       );
       const blockedByClient = new Map(
@@ -374,9 +401,12 @@ export class VictoriaLogsProvider implements LogProvider {
     return { items, totalCount };
   }
 
-  async getQueryTypesBreakdown(range: TimeRange): Promise<QueryTypeEntry[]> {
+  async getQueryTypesBreakdown(
+    range: TimeRange,
+    scope: LogScope = {},
+  ): Promise<QueryTypeEntry[]> {
     const rows = await this.queryRaw(
-      `${BASE_FILTER} | stats by (question_type) count() as count | format "<lc:question_type>" as __qtype_sort | sort by (count desc, __qtype_sort asc)`,
+      `${this.scopeQuery(scope)} | stats by (question_type) count() as count | format "<lc:question_type>" as __qtype_sort | sort by (count desc, __qtype_sort asc)`,
       { start: rangeToVlStart(range) },
     );
     const totalCount = rows.reduce((s, r) => s + Number(r.count), 0);
@@ -390,6 +420,25 @@ export class VictoriaLogsProvider implements LogProvider {
     });
   }
 
+  async getStats24h(): Promise<StatsResult> {
+    // VictoriaLogs does not support conditional aggregation (count(if(...))),
+    // so total and blocked counts require separate queries.
+    const [totalResult, blockedResult] = await Promise.all([
+      this.queryRaw(`${BASE_FILTER} | stats count() as total`, {
+        start: "24h",
+      }),
+      this.queryRaw(
+        `${BASE_FILTER} AND response_type:BLOCKED | stats count() as blocked`,
+        { start: "24h" },
+      ),
+    ]);
+
+    return {
+      totalQueries: Number(totalResult[0]?.total ?? 0),
+      blocked: Number(blockedResult[0]?.blocked ?? 0),
+    };
+  }
+
   async searchDomains(options: {
     range: TimeRange;
     query: string;
@@ -398,7 +447,7 @@ export class VictoriaLogsProvider implements LogProvider {
     if (!options.query.trim()) return [];
 
     const rows = await this.queryRaw(
-      `${BASE_FILTER} AND question_name:~"(?i)${escapeRegex(options.query)}" | stats by (question_name) count() as count | format "<lc:question_name>" as __qname_sort | sort by (count desc, __qname_sort asc) | limit ${options.limit}`,
+      `${BASE_FILTER} AND ${regexFilter("question_name", options.query)} | stats by (question_name) count() as count | format "<lc:question_name>" as __qname_sort | sort by (count desc, __qname_sort asc) | limit ${options.limit}`,
       { start: rangeToVlStart(options.range) },
     );
     return rows.map((r) => ({
@@ -415,7 +464,7 @@ export class VictoriaLogsProvider implements LogProvider {
     if (!options.query.trim()) return [];
 
     const rows = await this.queryRaw(
-      `${BASE_FILTER} AND client_names:~"(?i)${escapeRegex(options.query)}" | stats by (client_names) count() as count | format "<lc:client_names>" as __client_sort | sort by (count desc, __client_sort asc) | limit ${options.limit}`,
+      `${BASE_FILTER} AND ${regexFilter("client_names", options.query)} | stats by (client_names) count() as count | format "<lc:client_names>" as __client_sort | sort by (count desc, __client_sort asc) | limit ${options.limit}`,
       { start: rangeToVlStart(options.range) },
     );
     return rows.map((r) => ({


### PR DESCRIPTION
Query-log providers now share consistent filtering, ordering and pagination behavior. CSV parsing handles quoted records and orders rows by timestamp; SQL providers expose separate row and count reads, with bounded MySQL search and provider-specific query hints.

Adds exact hostname filtering, stable chart buckets and reusable connection storage for the later multi-server history work. Existing callers remain supported.

Validated with provider conformance tests against real databases and a 70,000-row MySQL fixture covering recent-window searches, fallback pagination and exact hostname exclusions. Static checks pass.

Part 1 of 7 in the multi-server stack. Review against `main`.
