### PR TITLE
Add reusable query-log export and fixture imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,10 @@ bun dev
 
 Visit `http://localhost:3000` to access BlockyUI.
 
+### Test providers with real query logs
+
+Use `bun run log-data --help` to export a read-only MySQL snapshot and copy it into disposable MySQL, PostgreSQL, Timescale, SQLite, CSV or VictoriaLogs stores. See the [data transfer guide](scripts/log-data/README.md) for setup, timezone handling and format differences.
+
 ## ⭐ Star History
 
 [![Star History Chart](https://api.star-history.com/svg?repos=gabeduartem/blocky-ui&type=date&legend=top-left)](https://www.star-history.com/#gabeduartem/blocky-ui&type=date&legend=top-left)

--- a/bun.lock
+++ b/bun.lock
@@ -36,6 +36,7 @@
         "sonner": "2.0.7",
         "superjson": "2.2.6",
         "tailwind-merge": "3.6.0",
+        "yaml": "2.9.0",
         "zod": "4.4.3",
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "knip": "SKIP_ENV_VALIDATION=true knip",
     "checkdupe": "jscpd",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "log-data": "bunx tsx scripts/log-data/cli.ts"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "1.1.19",
@@ -44,6 +45,7 @@
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
     "cmdk": "1.1.1",
+    "csv-parse": "7.0.2",
     "date-fns": "4.4.0",
     "drizzle-orm": "0.45.2",
     "ky": "2.0.2",
@@ -57,8 +59,8 @@
     "sonner": "2.0.7",
     "superjson": "2.2.6",
     "tailwind-merge": "3.6.0",
-    "zod": "4.4.3",
-    "csv-parse": "7.0.2"
+    "yaml": "2.9.0",
+    "zod": "4.4.3"
   },
   "devDependencies": {
     "@changesets/changelog-github": "0.7.0",

--- a/renovate.json
+++ b/renovate.json
@@ -51,5 +51,19 @@
       "matchPackageNames": ["@tanstack/react-query"],
       "schedule": ["every 1 week on friday"]
     }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^scripts/log-data/__tests__/.*\\.ts$/",
+        "/^src/server/logs/__tests__/.*\\.ts$/"
+      ],
+      "matchStrings": [
+        "[\"\\'](?<depName>[a-z][a-z0-9./_-]*):(?<currentValue>v?[0-9][a-zA-Z0-9._-]*)[\"\\']"
+      ],
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "docker"
+    }
   ]
 }

--- a/scripts/log-data/README.md
+++ b/scripts/log-data/README.md
@@ -45,7 +45,7 @@ Exports stream in primary-key order under a read-only, repeatable-read MySQL tra
 
 MySQL DATETIME does not store a timezone. The default interpretation is UTC. Set `--offset +02:00` only when that fixed offset matches how your source wrote the entire selected dataset. A dataset spanning daylight-saving changes in local wall time cannot be unambiguously reconstructed using a single offset.
 
-Imports preserve event timestamps by default. To move the dataset into a dashboard's current time window, add `--latest-at 2026-09-09T12:00:00.000Z`. This shifts every event by the same amount, preserving spacing. `--hostname blocky-two` changes the instance hostname. The command reports the shift and override. Import the same snapshot into multiple fresh stores to compare providers or instance counts without repeatedly reading production.
+Imports preserve event timestamps by default. To move the dataset into a dashboard's current time window, add `--latest-at "<UTC ISO timestamp>"`, replacing the placeholder with the desired current UTC timestamp. This shifts every event by the same amount, preserving spacing. `--hostname blocky-two` changes the instance hostname. The command reports the shift and override. Import the same snapshot into multiple fresh stores to compare providers or instance counts without repeatedly reading production.
 
 ## Comparing the dashboard
 

--- a/scripts/log-data/README.md
+++ b/scripts/log-data/README.md
@@ -70,7 +70,6 @@ VictoriaLogs imports check the final indexed count, not a full content fingerpri
 
 Keep snapshots and imported data outside the repository. They contain real browsing history. New snapshot and file directories use owner-only permissions. A failed snapshot has no completion manifest and cannot pass verification.
 
-The integration tests use a pinned Blocky image to verify native schemas and log formats. Renovate tracks the container image versions in the tests and opens update PRs, so CI checks compatibility before an update is merged.
 
 ```sh
 bun run test scripts/log-data/__tests__/transfer.test.ts

--- a/scripts/log-data/README.md
+++ b/scripts/log-data/README.md
@@ -1,0 +1,85 @@
+# Copy Blocky query logs between providers
+
+This development tool exports MySQL/MariaDB query logs once, then imports that snapshot into separate test stores. It does not modify the source or create database tables. SQL destinations must be initialized by Blocky and empty, with their Blocky writer stopped during import.
+
+```sh
+# Set SOURCE_URL using your local secret configuration, preferably a read-only account.
+bun run log-data export --source-env SOURCE_URL --out /tmp/blocky-snapshot
+bun run log-data verify --snapshot /tmp/blocky-snapshot
+
+# TARGET_URL points to an empty, disposable PostgreSQL database initialized by Blocky.
+bun run log-data import --snapshot /tmp/blocky-snapshot --to postgresql --target-env TARGET_URL
+
+bun run log-data import --snapshot /tmp/blocky-snapshot --to csv --out /tmp/blocky-csv
+bun run log-data import --snapshot /tmp/blocky-snapshot --to csv-client --out /tmp/blocky-clients
+bun run log-data import --snapshot /tmp/blocky-snapshot --to console --out /tmp/blocky-console
+```
+
+SQL destinations are `mysql`, `postgresql`, `timescale` and `sqlite`. For SQLite, the target environment variable contains an existing database file path. `victorialogs` accepts the HTTP base URL of an empty VictoriaLogs instance and ingests console events directly. `console` writes JSON lines that can instead go through your normal log collector.
+
+## Initialize a destination
+
+Create an empty database on your throwaway MySQL, PostgreSQL or Timescale instance. Start Blocky with a minimal configuration pointing `queryLog` at that database, wait for its HTTP API to become ready, then stop Blocky before importing. For example:
+
+```yaml
+ports:
+  dns: 53
+  http: 4000
+upstreams:
+  groups:
+    default: [1.1.1.1]
+queryLog:
+  type: postgresql
+  target: postgres://test:test@postgres:5432/blocky?sslmode=disable
+  flushInterval: 1s
+  logRetentionDays: 0
+```
+
+For MySQL, Blocky expects a Go DSN such as `test:test@tcp(mysql:3306)/blocky?charset=utf8mb4&parseTime=True&loc=UTC`. This tool expects a URL such as `mysql://test:test@localhost:3306/blocky`. For SQLite, use `type: sqlite` and a writable file path. Timescale needs the extension installed and `type: timescale`. Set a long positive `logRetentionDays`, such as `36500`, for a retained Timescale fixture. Blocky v0.34.0 installs a zero-day Timescale retention policy when this is `0`, even though `0` disables cleanup for the other providers. Use UTC for destination Blocky processes.
+
+The integration test in `__tests__/transfer.test.ts` contains executable examples using disposable containers and native Blocky initialization.
+
+## Reuse the data for scenarios
+
+Exports stream in primary-key order under a read-only, repeatable-read MySQL transaction. Only InnoDB is supported. `--limit 10000` captures the first 10,000 retained records by ID for a small experiment. A large export keeps an old transaction snapshot alive until it finishes, so use a replica or a bounded export when production load matters.
+
+MySQL DATETIME does not store a timezone. The default interpretation is UTC. Set `--offset +02:00` only when that fixed offset matches how your source wrote the entire selected dataset. A dataset spanning daylight-saving changes in local wall time cannot be unambiguously reconstructed using a single offset.
+
+Imports preserve event timestamps by default. To move the dataset into a dashboard's current time window, add `--latest-at 2026-09-09T12:00:00.000Z`. This shifts every event by the same amount, preserving spacing. `--hostname blocky-two` changes the instance hostname. The command reports the shift and override. Import the same snapshot into multiple fresh stores to compare providers or instance counts without repeatedly reading production.
+
+## Comparing the dashboard
+
+A snapshot copies query-log history, not the Blocky deployment. The dashboard's overview cards use the live `/api/stats` endpoint. Fresh Blocky processes have fresh counters, cache contents and their own configured blocklists, regardless of the imported history.
+
+Select one destination at a time to compare it with the source. Selecting several independent copies combines their events. Snapshots do not receive later source traffic. CSV imports contain all exported days, but the dashboard's CSV readers currently display only the latest day.
+
+## What is preserved
+
+The gzip JSON-lines snapshot preserves the 12 event fields, including nulls and duplicate events. Its manifest records row count, timestamp range and an order-independent SHA-256 multiset fingerprint. Source database IDs are omitted; each destination uses its native identity scheme.
+
+SQL imports use bounded batches and a transaction, then read every inserted event back and compare count and fingerprint before committing. They do not add indexes or run migrations. Destination IDs and sequences may advance even when an import rolls back. Stop other writers while importing.
+
+CSV and console cannot represent all database fields:
+
+- Neither stores `effective_tldp`, database IDs or the distinction between null and empty strings.
+- MySQL already normalized DNS names to lowercase without the final dot. File and console exports restore the dot, but cannot recover the original spelling.
+- CSV uses Blocky's tab-separated CSV quoting and UTC daily filenames. Timestamps lose milliseconds. Per-client filenames reconstruct client lists by splitting the stored name on `; `.
+- Console omits zero-valued fields, including a zero duration. It uses request time where the original console event would have used log emission time.
+
+VictoriaLogs imports check the final indexed count, not a full content fingerprint. Configure sufficient retention or explicitly shift old data first. VictoriaLogs and file outputs have no rollback. Discard a partial test destination before retrying; the tool does not retry writes automatically.
+
+Keep snapshots and imported data outside the repository. They contain real browsing history. New snapshot and file directories use owner-only permissions. A failed snapshot has no completion manifest and cannot pass verification.
+
+The native format reference is [Blocky v0.34.0's querylog package](https://github.com/0xERR0R/blocky/tree/v0.34.0/querylog). Format compatibility is version-specific, so rerun the integration tests when updating Blocky.
+
+```sh
+bun run test scripts/log-data/__tests__/transfer.test.ts
+```
+
+To run the same SQL and VictoriaLogs import checks against a local snapshot, set `BLOCKY_TRANSFER_SNAPSHOT`:
+
+```sh
+BLOCKY_TRANSFER_SNAPSHOT=/path/to/snapshot bun run test scripts/log-data
+```
+
+This still creates disposable destination containers. It never reconnects to the snapshot's original database. The native-writer and malformed-data tests run alongside the supplied dataset.

--- a/scripts/log-data/README.md
+++ b/scripts/log-data/README.md
@@ -70,7 +70,7 @@ VictoriaLogs imports check the final indexed count, not a full content fingerpri
 
 Keep snapshots and imported data outside the repository. They contain real browsing history. New snapshot and file directories use owner-only permissions. A failed snapshot has no completion manifest and cannot pass verification.
 
-The native format reference is [Blocky v0.34.0's querylog package](https://github.com/0xERR0R/blocky/tree/v0.34.0/querylog). Format compatibility is version-specific, so rerun the integration tests when updating Blocky.
+The integration tests use a pinned Blocky image to verify native schemas and log formats. Renovate tracks the container image versions in the tests and opens update PRs, so CI checks compatibility before an update is merged.
 
 ```sh
 bun run test scripts/log-data/__tests__/transfer.test.ts

--- a/scripts/log-data/__tests__/record.test.ts
+++ b/scripts/log-data/__tests__/record.test.ts
@@ -1,0 +1,55 @@
+import { expect, it } from "vitest";
+import {
+  fingerprint,
+  recordSchema,
+  timestamp,
+  transformRecord,
+} from "../record";
+
+const record = recordSchema.parse({
+  requestTs: "2026-08-10T16:53:58.492Z",
+  clientIp: "192.0.2.1",
+  clientName: "laptop",
+  durationMs: 0,
+  reason: "CUSTOMDNS",
+  responseType: "CUSTOMDNS",
+  questionType: "A",
+  questionName: "example.test",
+  effectiveTldp: "example.test",
+  answer: "A (192.0.2.42)",
+  responseCode: "NOERROR",
+  hostname: "blocky",
+});
+
+it("normalizes native SQL timestamps and applies explicit source offsets", () => {
+  expect(timestamp("2026-08-10 18:53:58.492", "+02:00")).toBe(record.requestTs);
+  expect(timestamp("2026-08-10 16:53:58.492+00")).toBe(record.requestTs);
+  expect(timestamp("2026-08-10 16:53:58.492+00:00")).toBe(record.requestTs);
+  expect(() => timestamp("invalid")).toThrow("timestamp");
+});
+
+it("fingerprints event multiplicity independently of database order or IDs", () => {
+  const a = fingerprint();
+  const b = fingerprint();
+  const other = { ...record, answer: null };
+  for (const value of [record, record, other]) {
+    a.add(value);
+  }
+  for (const value of [other, record, record]) {
+    b.add(value);
+  }
+  expect(a.result()).toEqual(b.result());
+  b.add(record);
+  expect(a.result()).not.toEqual(b.result());
+});
+
+it("shifts timestamps and hostnames only when requested", () => {
+  expect(transformRecord(record, { shiftMs: 0 })).toEqual(record);
+  expect(
+    transformRecord(record, { shiftMs: 3600000, hostname: "second" }),
+  ).toEqual({
+    ...record,
+    requestTs: "2026-08-10T17:53:58.492Z",
+    hostname: "second",
+  });
+});

--- a/scripts/log-data/__tests__/snapshot-validation.test.ts
+++ b/scripts/log-data/__tests__/snapshot-validation.test.ts
@@ -1,0 +1,100 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, expect, it, vi } from "vitest";
+import { recordSchema } from "../record";
+import { verifySnapshot, writeSnapshot } from "../snapshot";
+import { importFiles } from "../import-files";
+import { importVictoriaLogs } from "../import-victorialogs";
+
+const sample = recordSchema.parse({
+  requestTs: "2026-09-10T10:00:00.000Z",
+  clientIp: null,
+  clientName: null,
+  durationMs: 0,
+  reason: null,
+  responseType: "RESOLVED",
+  questionType: "A",
+  questionName: "example.test",
+  effectiveTldp: null,
+  answer: null,
+  responseCode: "NOERROR",
+  hostname: "blocky",
+});
+
+async function* records() {
+  yield sample;
+  yield { ...sample, requestTs: "2026-09-10T11:00:00.000Z" };
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+it.each(["firstTimestamp", "lastTimestamp"])(
+  "rejects an altered %s before import",
+  async (field) => {
+    const directory = await mkdtemp(join(tmpdir(), "snapshot-bounds-"));
+
+    try {
+      const target = join(directory, "snapshot");
+      const manifest = await writeSnapshot(target, records(), "+00:00");
+      expect(await verifySnapshot(target)).toEqual(manifest);
+
+      await writeFile(
+        join(target, "manifest.json"),
+        JSON.stringify({ ...manifest, [field]: "2025-01-01T00:00:00.000Z" }),
+      );
+
+      await expect(verifySnapshot(target)).rejects.toThrow("do not match");
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  },
+);
+
+it("creates output parents but refuses to overwrite an existing import", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "import-parents-"));
+
+  try {
+    const target = join(directory, "nested", "logs");
+    expect(await importFiles("console", target, records())).toEqual({
+      count: 2,
+    });
+    const file = join(target, "querylog.jsonl");
+    const original = await readFile(file, "utf8");
+
+    await expect(importFiles("console", target, records())).rejects.toThrow(
+      "EEXIST",
+    );
+    expect(await readFile(file, "utf8")).toBe(original);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+it.each(["/vlogs", "/vlogs/", "/vlogs?tenant=demo"])(
+  "preserves the VictoriaLogs prefix %s for count and insert",
+  async (path) => {
+    const requests: URL[] = [];
+    let inserted = false;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: URL) => {
+        requests.push(url);
+        if (url.pathname.endsWith("insert/jsonline")) {
+          inserted = true;
+          return new Response("");
+        }
+        return Response.json({ total: inserted ? 2 : 0 });
+      }),
+    );
+
+    expect(
+      await importVictoriaLogs(`http://example.test${path}`, records()),
+    ).toEqual({ count: 2 });
+    expect(requests.map((url) => url.pathname)).toEqual([
+      "/vlogs/select/logsql/query",
+      "/vlogs/insert/jsonline",
+      "/vlogs/select/logsql/query",
+    ]);
+  },
+);

--- a/scripts/log-data/__tests__/transfer.test.ts
+++ b/scripts/log-data/__tests__/transfer.test.ts
@@ -56,7 +56,7 @@ function importSnapshot() {
 }
 
 async function blocky(type: string, target: string, output?: string) {
-  const container = new GenericContainer("ghcr.io/0xerr0r/blocky:v0.34.0")
+  const container = new GenericContainer("ghcr.io/0xerr0r/blocky:v0.35.0")
     .withNetwork(network)
     .withExposedPorts(4000)
     .withCopyContentToContainer([

--- a/scripts/log-data/__tests__/transfer.test.ts
+++ b/scripts/log-data/__tests__/transfer.test.ts
@@ -10,6 +10,7 @@ import {
 import {
   mkdtemp,
   chmod,
+  cp,
   readFile,
   readdir,
   rm,
@@ -267,7 +268,9 @@ describe("portable Blocky logs", () => {
     await chmod(folder, 0o777);
     const writer = await blocky("sqlite", "/data/blocky.db", folder);
     await writer.stop();
-    const target = join(folder, "blocky.db");
+    const importedFolder = join(directory, "sqlite-import");
+    await cp(folder, importedFolder, { recursive: true });
+    const target = join(importedFolder, "blocky.db");
 
     async function* broken() {
       for (let index = 0; index < 501; index++) {

--- a/scripts/log-data/__tests__/transfer.test.ts
+++ b/scripts/log-data/__tests__/transfer.test.ts
@@ -1,0 +1,394 @@
+import { streamAndParseEntries } from "~/server/logs/csv/utils";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  GenericContainer,
+  Network,
+  Wait,
+  type StartedNetwork,
+  type StartedTestContainer,
+} from "testcontainers";
+import {
+  mkdtemp,
+  chmod,
+  readFile,
+  readdir,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createConnection } from "mysql2/promise";
+import { stringify } from "yaml";
+import { exportMysql } from "../export-mysql";
+import { importSql } from "../import-sql";
+import { importFiles, csvLine, consoleRecord } from "../import-files";
+import { importVictoriaLogs } from "../import-victorialogs";
+import { readSnapshot, verifySnapshot, writeSnapshot } from "../snapshot";
+import { type RecordEntry } from "../record";
+import { drizzle } from "drizzle-orm/mysql2";
+import { logEntries } from "~/server/logs/mysql/schema";
+
+const cleanup: Array<() => Promise<unknown>> = [];
+let directory: string;
+let network: StartedNetwork;
+let sourceUrl: string;
+let sample: RecordEntry[];
+
+async function* records(entries = sample) {
+  yield* entries;
+}
+
+async function query(writer: StartedTestContainer) {
+  const response = await fetch(
+    `http://${writer.getHost()}:${writer.getMappedPort(4000)}/api/query`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ query: "transfer.test", type: "A" }),
+    },
+  );
+  expect(response.ok).toBe(true);
+}
+
+function importSnapshot() {
+  return process.env["BLOCKY_TRANSFER_SNAPSHOT"] ?? join(directory, "paged");
+}
+
+async function blocky(type: string, target: string, output?: string) {
+  const container = new GenericContainer("ghcr.io/0xerr0r/blocky:v0.34.0")
+    .withNetwork(network)
+    .withExposedPorts(4000)
+    .withCopyContentToContainer([
+      {
+        target: "/app/config.yml",
+        content: stringify({
+          ports: { dns: 53, http: 4000 },
+          upstreams: { groups: { default: ["1.1.1.1"] } },
+          customDNS: { mapping: { "transfer.test": "192.0.2.42" } },
+          queryLog: { type, target, flushInterval: "1s", logRetentionDays: 0 },
+          log: { level: "info", format: "json" },
+        }),
+      },
+    ])
+    .withWaitStrategy(Wait.forHttp("/api/blocking/status", 4000));
+
+  if (output) {
+    container
+      .withUser("0:0")
+      .withBindMounts([{ source: output, target: "/data", mode: "rw" }]);
+  }
+
+  const started = await container.start();
+  cleanup.push(() => started.stop());
+  return started;
+}
+
+beforeAll(async () => {
+  directory = await mkdtemp(join(tmpdir(), "blocky-transfer-"));
+  cleanup.push(() => rm(directory, { recursive: true, force: true }));
+  network = await new Network().start();
+  cleanup.push(() => network.stop());
+
+  const mysql = await new GenericContainer("mariadb:11")
+    .withNetwork(network)
+    .withNetworkAliases("source")
+    .withEnvironment({
+      MARIADB_ROOT_PASSWORD: "transfer-test",
+      MARIADB_DATABASE: "blocky",
+    })
+    .withExposedPorts(3306)
+    .withWaitStrategy(Wait.forLogMessage(/ready for connections/, 2))
+    .start();
+  cleanup.push(() => mysql.stop());
+  sourceUrl = `mysql://root:transfer-test@${mysql.getHost()}:${mysql.getMappedPort(3306)}/blocky`;
+  const writer = await blocky(
+    "mysql",
+    "root:transfer-test@tcp(source:3306)/blocky?charset=utf8mb4&parseTime=True&loc=UTC",
+  );
+
+  for (let index = 0; index < 3; index++) {
+    await query(writer);
+  }
+
+  await vi.waitFor(
+    async () => {
+      const connection = await createConnection(sourceUrl);
+      try {
+        const [rows] = await connection.query(
+          "SELECT COUNT(*) AS total FROM log_entries",
+        );
+        expect(JSON.stringify(rows)).toBe('[{"total":3}]');
+      } finally {
+        await connection.end();
+      }
+    },
+    { timeout: 10_000 },
+  );
+  await writer.stop();
+
+  const manifest = await exportMysql({
+    url: sourceUrl,
+    output: join(directory, "snapshot"),
+  });
+  expect(manifest.count).toBe(3);
+  sample = [];
+  for await (const row of readSnapshot(join(directory, "snapshot"))) {
+    sample.push(row);
+  }
+}, 120_000);
+
+afterAll(async () => {
+  for (const stop of cleanup.reverse()) {
+    await stop();
+  }
+}, 120_000);
+
+describe("portable Blocky logs", () => {
+  it("exports native MySQL records without changing them and checks snapshot integrity", async () => {
+    const snapshot = join(directory, "snapshot");
+    expect((await verifySnapshot(snapshot)).count).toBe(3);
+    expect(sample[0]?.questionName).toBe("transfer.test");
+    expect(sample[0]?.answer).toBe("A (192.0.2.42)");
+    expect(
+      (
+        await exportMysql({
+          url: sourceUrl,
+          output: join(directory, "limited"),
+          limit: 2,
+        })
+      ).count,
+    ).toBe(2);
+
+    const corrupt = join(directory, "corrupt");
+    await writeSnapshot(corrupt, records(), "+00:00");
+    await writeFile(join(corrupt, "records.jsonl.gz"), "broken");
+    await expect(verifySnapshot(corrupt)).rejects.toThrow();
+  });
+
+  it("crosses MySQL page boundaries without dropping duplicates or changing the source", async () => {
+    const first = sample[0];
+    if (!first) {
+      throw new Error("Missing native record");
+    }
+    const connection = await createConnection(sourceUrl);
+    try {
+      const db = drizzle(connection);
+      for (let page = 0; page < 3; page++) {
+        await db.insert(logEntries).values(
+          Array.from({ length: 500 }, (_, index) => ({
+            ...first,
+            requestTs: first.requestTs.replace("T", " ").replace("Z", ""),
+            answer: index % 2 ? null : 'quoted "value"\twith\nnewlines é',
+            clientName: "client; laptop",
+          })),
+        );
+      }
+      const [before] = await connection.query(
+        "SELECT COUNT(*) AS total, MAX(id) AS lastId FROM log_entries",
+      );
+      const result = await exportMysql({
+        url: sourceUrl,
+        output: join(directory, "paged"),
+      });
+      expect(result.count).toBe(1503);
+      expect(await verifySnapshot(join(directory, "paged"))).toEqual(result);
+      const [after] = await connection.query(
+        "SELECT COUNT(*) AS total, MAX(id) AS lastId FROM log_entries",
+      );
+      expect(after).toEqual(before);
+    } finally {
+      await connection.end();
+    }
+  });
+
+  it("imports MySQL into a native empty table and refuses a second import", async () => {
+    const connection = await createConnection(sourceUrl);
+    await connection.query("CREATE DATABASE transfer_target");
+    await connection.end();
+    const writer = await blocky(
+      "mysql",
+      "root:transfer-test@tcp(source:3306)/transfer_target?charset=utf8mb4&parseTime=True&loc=UTC",
+    );
+    await writer.stop();
+    const target = new URL(sourceUrl);
+    target.pathname = "/transfer_target";
+    expect(
+      (
+        await importSql(
+          "mysql",
+          target.toString(),
+          readSnapshot(importSnapshot()),
+        )
+      ).count,
+    ).toBe((await verifySnapshot(importSnapshot())).count);
+    await expect(
+      importSql("mysql", target.toString(), records()),
+    ).rejects.toThrow("empty");
+  }, 120_000);
+
+  it.each([
+    ["postgresql", "postgres:16"],
+    ["timescale", "timescale/timescaledb:2.26.0-pg16"],
+  ] as const)(
+    "imports into native %s and refuses to overwrite it",
+    async (type, image) => {
+      const pg = await new GenericContainer(image)
+        .withNetwork(network)
+        .withNetworkAliases(`target-${type}`)
+        .withEnvironment({
+          POSTGRES_PASSWORD: "transfer-test",
+          POSTGRES_DB: "blocky",
+        })
+        .withExposedPorts(5432)
+        .withWaitStrategy(
+          Wait.forLogMessage(
+            /database system is ready to accept connections/,
+            2,
+          ),
+        )
+        .start();
+      cleanup.push(() => pg.stop());
+      const writer = await blocky(
+        type,
+        `postgres://postgres:transfer-test@target-${type}:5432/blocky?sslmode=disable`,
+      );
+      await writer.stop();
+      const url = `postgres://postgres:transfer-test@${pg.getHost()}:${pg.getMappedPort(5432)}/blocky`;
+      expect(
+        (await importSql(type, url, readSnapshot(importSnapshot()))).count,
+      ).toBe((await verifySnapshot(importSnapshot())).count);
+      await expect(importSql(type, url, records())).rejects.toThrow("empty");
+    },
+    120_000,
+  );
+
+  it("imports into a native SQLite file and rolls back an interrupted import", async () => {
+    const folder = await mkdtemp(join(directory, "sqlite-"));
+    await chmod(folder, 0o777);
+    const writer = await blocky("sqlite", "/data/blocky.db", folder);
+    await writer.stop();
+    const target = join(folder, "blocky.db");
+
+    async function* broken() {
+      for (let index = 0; index < 501; index++) {
+        yield* sample;
+      }
+      throw new Error("interrupted");
+    }
+
+    await expect(importSql("sqlite", target, broken())).rejects.toThrow(
+      "interrupted",
+    );
+    expect(
+      (await importSql("sqlite", target, readSnapshot(importSnapshot()))).count,
+    ).toBe((await verifySnapshot(importSnapshot())).count);
+    await expect(importSql("sqlite", target, records())).rejects.toThrow(
+      "empty",
+    );
+  }, 120_000);
+
+  it("writes native file formats and imports console events into VictoriaLogs", async () => {
+    for (const type of ["csv", "csv-client", "console"] as const) {
+      expect(
+        (await importFiles(type, join(directory, type), records())).count,
+      ).toBe(3);
+      await expect(
+        importFiles(type, join(directory, type), records()),
+      ).rejects.toThrow();
+    }
+
+    const lines = await readFile(
+      join(directory, "console", "querylog.jsonl"),
+      "utf8",
+    );
+    expect(JSON.parse(lines.split("\n")[0] ?? "")).toEqual(
+      sample[0] ? consoleRecord(sample[0]) : undefined,
+    );
+    const victoria = await new GenericContainer(
+      "victoriametrics/victoria-logs:v1.48.0",
+    )
+      .withExposedPorts(9428)
+      .withCommand(["-retentionPeriod=100y"])
+      .withWaitStrategy(Wait.forHttp("/", 9428))
+      .start();
+    cleanup.push(() => victoria.stop());
+    const url = `http://${victoria.getHost()}:${victoria.getMappedPort(9428)}/`;
+    expect(
+      (await importVictoriaLogs(url, readSnapshot(importSnapshot()))).count,
+    ).toBe((await verifySnapshot(importSnapshot())).count);
+    await expect(importVictoriaLogs(url, records())).rejects.toThrow("empty");
+  }, 120_000);
+
+  it.each(["csv", "csv-client"] as const)(
+    "matches native Blocky %s field order and filenames",
+    async (type) => {
+      const folder = await mkdtemp(join(directory, `native-${type}-`));
+      await chmod(folder, 0o777);
+      const writer = await blocky(type, "/data", folder);
+      await query(writer);
+      await vi.waitFor(
+        async () => {
+          expect(
+            (await readdir(folder)).some((file) => file.endsWith(".log")),
+          ).toBe(true);
+        },
+        { timeout: 10_000 },
+      );
+      await writer.stop();
+      const filename = (await readdir(folder)).find((file) =>
+        file.endsWith(".log"),
+      );
+      const first = sample[0];
+      if (!filename || !first) {
+        throw new Error("Missing native output");
+      }
+      const native = await readFile(join(folder, filename), "utf8");
+      expect(native.trimEnd().split("\t").slice(4, 10)).toEqual(
+        csvLine(first).trimEnd().split("\t").slice(4, 10),
+      );
+      const converted = join(directory, `native-converted-${type}`);
+      await importFiles(
+        type,
+        converted,
+        records([{ ...first, clientName: native.split("\t")[2] ?? "" }]),
+      );
+      expect(await readdir(converted)).toContain(filename);
+    },
+    120_000,
+  );
+
+  it("reads quoted and multiline converted answers through the dashboard provider", async () => {
+    const first = sample[0];
+    if (!first) {
+      throw new Error("Missing native record");
+    }
+    const values = [
+      first,
+      { ...first, answer: 'TXT ("value\twith\nnewlines")' },
+    ];
+    const folder = join(directory, "quoted-csv");
+    await importFiles("csv", folder, records(values));
+    const filename = (await readdir(folder))[0];
+    if (!filename) {
+      throw new Error("Missing CSV output");
+    }
+    const actual = await streamAndParseEntries(join(folder, filename));
+    expect(actual.map((row) => row.answer)).toEqual(
+      values.map((row) => row.answer),
+    );
+  });
+
+  it("quotes tabs, newlines and quotes like Go's tab-separated CSV writer", () => {
+    const first = sample[0];
+    expect(first).toBeDefined();
+    if (!first) {
+      throw new Error("Missing native record");
+    }
+    expect(csvLine({ ...first, answer: 'a\t"b"\nc' })).toContain(
+      '"a\t""b""\nc"',
+    );
+    expect(consoleRecord({ ...first, durationMs: 0 })).not.toHaveProperty(
+      "duration_ms",
+    );
+  });
+});

--- a/scripts/log-data/cli.ts
+++ b/scripts/log-data/cli.ts
@@ -1,0 +1,177 @@
+import { TransferError } from "./errors";
+import { importVictoriaLogs } from "./import-victorialogs";
+import { parseArgs } from "node:util";
+import { z } from "zod";
+import { exportMysql } from "./export-mysql";
+import { importFiles } from "./import-files";
+import { importSql } from "./import-sql";
+import { readSnapshot, verifySnapshot } from "./snapshot";
+import { transformRecord } from "./record";
+
+const { values, positionals } = parseArgs({
+  allowPositionals: true,
+  options: {
+    "source-env": { type: "string" },
+    "target-env": { type: "string" },
+    out: { type: "string" },
+    snapshot: { type: "string" },
+    to: { type: "string" },
+    limit: { type: "string" },
+    offset: { type: "string", default: "+00:00" },
+    "latest-at": { type: "string" },
+    hostname: { type: "string" },
+    help: { type: "boolean" },
+  },
+});
+
+function required(value: string | undefined, name: string) {
+  if (!value) {
+    throw new TransferError(`Missing ${name}.`);
+  }
+  return value;
+}
+
+function environment(name: string | undefined, flag: string) {
+  return required(
+    process.env[required(name, flag)],
+    `environment variable named by ${flag}`,
+  );
+}
+
+async function main() {
+  const command = positionals[0];
+
+  if (values.help) {
+    console.log(`Export: log-data export --source-env SOURCE_URL --out ./snapshot [--limit 10000] [--offset +00:00]
+Verify: log-data verify --snapshot ./snapshot
+Import: log-data import --snapshot ./snapshot --to mysql|postgresql|timescale|sqlite --target-env TARGET
+Logs:   log-data import --snapshot ./snapshot --to victorialogs --target-env TARGET_URL
+Files:  log-data import --snapshot ./snapshot --to csv|csv-client|console --out ./logs
+Import options: --latest-at <UTC ISO timestamp> --hostname <name>
+SQL destinations must be empty and initialized by Blocky. SQLite TARGET is a file path.
+Console exports native JSON lines for ingestion into VictoriaLogs. See scripts/log-data/README.md.`);
+    return;
+  }
+
+  if (command === "export") {
+    const offset = z
+      .string()
+      .regex(/^[+-](?:0\d|1[0-3]):[0-5]\d$|^[+-]14:00$/)
+      .parse(values.offset);
+    const limit =
+      values.limit === undefined
+        ? undefined
+        : z.coerce.number().int().positive().parse(values.limit);
+    console.log(
+      JSON.stringify(
+        await exportMysql({
+          url: environment(values["source-env"], "--source-env"),
+          output: required(values.out, "--out"),
+          offset,
+          limit,
+        }),
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+
+  const snapshot = required(values.snapshot, "--snapshot");
+  const manifest = await verifySnapshot(snapshot);
+
+  if (command === "verify") {
+    console.log(JSON.stringify(manifest, null, 2));
+    return;
+  }
+
+  if (command !== "import") {
+    throw new TransferError(
+      "Choose export, import or verify. Use --help for examples.",
+    );
+  }
+
+  const type = z
+    .enum([
+      "mysql",
+      "postgresql",
+      "timescale",
+      "sqlite",
+      "csv",
+      "csv-client",
+      "console",
+      "victorialogs",
+    ])
+    .parse(values.to);
+  const latest =
+    values["latest-at"] === undefined
+      ? undefined
+      : z.iso.datetime().parse(values["latest-at"]);
+  const shiftMs =
+    latest && manifest.lastTimestamp
+      ? Date.parse(latest) - Date.parse(manifest.lastTimestamp)
+      : 0;
+
+  async function* records() {
+    for await (const record of readSnapshot(snapshot)) {
+      yield transformRecord(record, { shiftMs, hostname: values.hostname });
+    }
+  }
+
+  const result =
+    type === "csv" || type === "csv-client" || type === "console"
+      ? await importFiles(type, required(values.out, "--out"), records())
+      : type === "victorialogs"
+        ? await importVictoriaLogs(
+            environment(values["target-env"], "--target-env"),
+            records(),
+          )
+        : await importSql(
+            type,
+            environment(values["target-env"], "--target-env"),
+            records(),
+          );
+
+  console.log(
+    JSON.stringify(
+      {
+        destination: type,
+        ...result,
+        shiftMs,
+        hostname: values.hostname,
+        losses:
+          type === "console" ||
+          type === "victorialogs" ||
+          type === "csv" ||
+          type === "csv-client"
+            ? [
+                "No effective TLD field; null and empty values cannot be distinguished; original DNS spelling cannot be recovered.",
+                ...(type === "console" || type === "victorialogs"
+                  ? [
+                      "Request time substitutes for console emission time; zero values are omitted.",
+                    ]
+                  : [
+                      "Timestamps have UTC second precision; client filenames reconstruct names by splitting on '; '.",
+                    ]),
+              ]
+            : [],
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+try {
+  await main();
+} catch (error) {
+  // Driver errors can contain credentials or query values. Keep their details out of terminal output.
+  console.error(
+    error instanceof TransferError
+      ? error.message
+      : error instanceof Error
+        ? `Transfer failed (${error.name}). Check configuration, snapshot integrity and destination emptiness. No source data was modified.`
+        : "Transfer failed.",
+  );
+  process.exitCode = 1;
+}

--- a/scripts/log-data/errors.ts
+++ b/scripts/log-data/errors.ts
@@ -1,0 +1,3 @@
+export class TransferError extends Error {
+  override name = "TransferError";
+}

--- a/scripts/log-data/export-mysql.ts
+++ b/scripts/log-data/export-mysql.ts
@@ -1,0 +1,59 @@
+import { mysqlPages } from "./mysql-pages";
+import { requireTransactionalTable } from "./mysql-storage";
+import { createConnection } from "mysql2/promise";
+import { drizzle } from "drizzle-orm/mysql2";
+import { asc, gt } from "drizzle-orm";
+import { logEntries } from "~/server/logs/mysql/schema";
+import { recordSchema, timestamp } from "./record";
+import { writeSnapshot } from "./snapshot";
+
+export async function exportMysql(options: {
+  url: string;
+  output: string;
+  offset?: string;
+  limit?: number;
+}) {
+  const offset = options.offset ?? "+00:00";
+  const connection = await createConnection({
+    uri: options.url,
+    timezone: offset,
+    dateStrings: true,
+    supportBigNumbers: true,
+    bigNumberStrings: true,
+  });
+  const db = drizzle(connection);
+
+  try {
+    await requireTransactionalTable(connection);
+    await connection.query("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ");
+    await connection.query(
+      "START TRANSACTION WITH CONSISTENT SNAPSHOT, READ ONLY",
+    );
+
+    async function* records() {
+      const rows = mysqlPages(
+        (afterId, limit) =>
+          db
+            .select()
+            .from(logEntries)
+            .where(gt(logEntries.id, afterId))
+            .orderBy(asc(logEntries.id))
+            .limit(limit),
+        options.limit,
+      );
+
+      for await (const row of rows) {
+        yield recordSchema.parse({
+          ...row,
+          requestTs: timestamp(row.requestTs, offset),
+          durationMs: row.durationMs === null ? null : Number(row.durationMs),
+        });
+      }
+    }
+
+    return await writeSnapshot(options.output, records(), offset);
+  } finally {
+    await connection.query("ROLLBACK").catch(() => undefined);
+    await connection.end();
+  }
+}

--- a/scripts/log-data/import-files.ts
+++ b/scripts/log-data/import-files.ts
@@ -1,0 +1,112 @@
+import { appendFile, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { type RecordEntry } from "./record";
+
+export type FileDestination = "csv" | "csv-client" | "console";
+
+function quoteField(value: string) {
+  if (
+    value === "\\." ||
+    /[\t\n\r"]/.test(value) ||
+    /^\p{White_Space}/u.test(value)
+  ) {
+    return `"${value.replaceAll('"', '""')}"`;
+  }
+
+  return value;
+}
+
+function questionName(record: RecordEntry) {
+  const name = record.questionName ?? "";
+  return name && !name.endsWith(".") ? `${name}.` : name;
+}
+
+export function csvLine(record: RecordEntry) {
+  return (
+    [
+      record.requestTs.slice(0, 19).replace("T", " "),
+      record.clientIp ?? "",
+      record.clientName ?? "",
+      String(record.durationMs ?? 0),
+      record.reason ?? "",
+      questionName(record),
+      record.answer ?? "",
+      record.responseCode ?? "",
+      record.responseType ?? "",
+      record.questionType ?? "",
+      record.hostname ?? "",
+    ]
+      .map(quoteField)
+      .join("\t") + "\n"
+  );
+}
+
+export function consoleRecord(record: RecordEntry) {
+  const fields = {
+    client_ip: record.clientIp,
+    client_names: record.clientName,
+    duration_ms: record.durationMs,
+    response_reason: record.reason,
+    response_type: record.responseType,
+    response_code: record.responseCode,
+    question_name: questionName(record),
+    question_type: record.questionType,
+    answer: record.answer,
+    instance: record.hostname,
+  };
+
+  return {
+    time: record.requestTs,
+    level: "info",
+    msg: "query resolved",
+    prefix: "queryLog",
+    ...Object.fromEntries(
+      Object.entries(fields).filter(
+        ([, value]) => value !== null && value !== "" && value !== 0,
+      ),
+    ),
+  };
+}
+
+export async function importFiles(
+  type: FileDestination,
+  output: string,
+  records: AsyncIterable<RecordEntry>,
+) {
+  await mkdir(output, { mode: 0o700 });
+  let count = 0;
+  const buffers = new Map<string, string[]>();
+
+  async function flush() {
+    for (const [filename, lines] of buffers) {
+      await appendFile(join(output, filename), lines.join(""), { mode: 0o600 });
+    }
+    buffers.clear();
+  }
+
+  for await (const record of records) {
+    const client = (record.clientName ?? "")
+      .split("; ")
+      .join("-")
+      .replace(/[^a-zA-Z0-9_-]+/g, "_");
+    const filename =
+      type === "console"
+        ? "querylog.jsonl"
+        : `${record.requestTs.slice(0, 10)}_${type === "csv" ? "ALL" : client}.log`;
+    const lines = buffers.get(filename) ?? [];
+    lines.push(
+      type === "console"
+        ? `${JSON.stringify(consoleRecord(record))}\n`
+        : csvLine(record),
+    );
+    buffers.set(filename, lines);
+    count++;
+
+    if (count % 500 === 0) {
+      await flush();
+    }
+  }
+
+  await flush();
+  return { count };
+}

--- a/scripts/log-data/import-files.ts
+++ b/scripts/log-data/import-files.ts
@@ -1,5 +1,5 @@
 import { appendFile, mkdir } from "node:fs/promises";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { type RecordEntry } from "./record";
 
 export type FileDestination = "csv" | "csv-client" | "console";
@@ -73,6 +73,7 @@ export async function importFiles(
   output: string,
   records: AsyncIterable<RecordEntry>,
 ) {
+  await mkdir(dirname(output), { recursive: true, mode: 0o700 });
   await mkdir(output, { mode: 0o700 });
   let count = 0;
   const buffers = new Map<string, string[]>();

--- a/scripts/log-data/import-sql.ts
+++ b/scripts/log-data/import-sql.ts
@@ -1,0 +1,204 @@
+import { mysqlPages } from "./mysql-pages";
+import { asc, gt } from "drizzle-orm";
+import { TransferError } from "./errors";
+import { requireTransactionalTable } from "./mysql-storage";
+import { createConnection } from "mysql2/promise";
+import postgres from "postgres";
+import Database from "better-sqlite3";
+import { z } from "zod";
+import { drizzle as mysqlDrizzle } from "drizzle-orm/mysql2";
+import { drizzle as pgDrizzle } from "drizzle-orm/postgres-js";
+import { drizzle as sqliteDrizzle } from "drizzle-orm/better-sqlite3";
+import { logEntries as mysqlTable } from "~/server/logs/mysql/schema";
+import { logEntries as pgTable } from "~/server/logs/postgres/schema";
+import { logEntries as sqliteTable } from "~/server/logs/sqlite/schema";
+import {
+  fingerprint,
+  databaseRecord,
+  recordSchema,
+  timestamp,
+  type RecordEntry,
+} from "./record";
+
+export type SqlDestination = "mysql" | "postgresql" | "timescale" | "sqlite";
+
+type Store = {
+  hasRows: () => Promise<boolean>;
+  insert: (records: RecordEntry[]) => Promise<unknown>;
+  rows: () => AsyncIterable<unknown> | Iterable<unknown>;
+};
+
+async function transfer(store: Store, records: AsyncIterable<RecordEntry>) {
+  if (await store.hasRows()) {
+    throw new TransferError("The destination log_entries table must be empty.");
+  }
+
+  const expected = fingerprint();
+  let batch: RecordEntry[] = [];
+
+  for await (const record of records) {
+    expected.add(record);
+    batch.push(record);
+
+    if (batch.length === 500) {
+      await store.insert(batch);
+      batch = [];
+    }
+  }
+
+  if (batch.length > 0) {
+    await store.insert(batch);
+  }
+
+  const actual = fingerprint();
+
+  for await (const value of store.rows()) {
+    const row = z.record(z.string(), z.unknown()).parse(value);
+    const parsed = recordSchema.parse({
+      ...row,
+      requestTs: timestamp(row.requestTs),
+      durationMs: row.durationMs === null ? null : Number(row.durationMs),
+    });
+    actual.add(parsed);
+  }
+
+  if (JSON.stringify(actual.result()) !== JSON.stringify(expected.result())) {
+    throw new TransferError(
+      "Destination verification failed. The import has been rolled back.",
+    );
+  }
+
+  return actual.result();
+}
+
+export async function importSql(
+  type: SqlDestination,
+  target: string,
+  records: AsyncIterable<RecordEntry>,
+) {
+  if (type === "mysql") {
+    const connection = await createConnection({
+      uri: target,
+      timezone: "Z",
+      dateStrings: true,
+    });
+
+    try {
+      await requireTransactionalTable(connection);
+      return await mysqlDrizzle(connection).transaction(async (tx) =>
+        transfer(
+          {
+            hasRows: async () =>
+              (
+                await tx
+                  .select({ id: mysqlTable.id })
+                  .from(mysqlTable)
+                  .limit(1)
+                  .for("update")
+              ).length > 0,
+            insert: (batch) =>
+              tx.insert(mysqlTable).values(
+                batch.map((record) => ({
+                  ...record,
+                  requestTs: record.requestTs
+                    .replace("T", " ")
+                    .replace("Z", ""),
+                })),
+              ),
+            rows: () =>
+              mysqlPages((afterId, limit) =>
+                tx
+                  .select()
+                  .from(mysqlTable)
+                  .where(gt(mysqlTable.id, afterId))
+                  .orderBy(asc(mysqlTable.id))
+                  .limit(limit),
+              ),
+          },
+          records,
+        ),
+      );
+    } finally {
+      await connection.end();
+    }
+  }
+
+  if (type === "sqlite") {
+    const connection = new Database(target, { fileMustExist: true });
+    const db = sqliteDrizzle(connection);
+
+    try {
+      connection.exec("BEGIN IMMEDIATE");
+      const result = await transfer(
+        {
+          hasRows: async () =>
+            db.select().from(sqliteTable).limit(1).all().length > 0,
+          insert: async (batch) =>
+            db
+              .insert(sqliteTable)
+              .values(
+                batch.map((record) => ({
+                  ...record,
+                  requestTs: record.requestTs
+                    .replace("T", " ")
+                    .replace("Z", "+00:00"),
+                })),
+              )
+              .run(),
+          rows: function* () {
+            for (const row of connection
+              .prepare(db.select().from(sqliteTable).toSQL().sql)
+              .iterate()) {
+              yield databaseRecord(row);
+            }
+          },
+        },
+        records,
+      );
+      connection.exec("COMMIT");
+      return result;
+    } catch (error) {
+      if (connection.inTransaction) {
+        connection.exec("ROLLBACK");
+      }
+      throw error;
+    } finally {
+      connection.close();
+    }
+  }
+
+  const connection = postgres(target, { max: 1 });
+
+  try {
+    return await connection.begin(async (sql) => {
+      await sql`LOCK TABLE log_entries IN EXCLUSIVE MODE`;
+      const db = pgDrizzle(connection);
+
+      return transfer(
+        {
+          hasRows: async () =>
+            (await sql`SELECT 1 FROM log_entries LIMIT 1`).length > 0,
+          insert: async (batch) => {
+            const query = db.insert(pgTable).values(batch).toSQL();
+            const parameters = z
+              .array(z.union([z.string(), z.number(), z.null()]))
+              .parse(query.params);
+            await sql.unsafe(query.sql, parameters);
+          },
+          rows: async function* () {
+            const query = db.select().from(pgTable).toSQL();
+
+            for await (const rows of sql.unsafe(query.sql).cursor(500)) {
+              for (const row of rows) {
+                yield databaseRecord(row);
+              }
+            }
+          },
+        },
+        records,
+      );
+    });
+  } finally {
+    await connection.end();
+  }
+}

--- a/scripts/log-data/import-victorialogs.ts
+++ b/scripts/log-data/import-victorialogs.ts
@@ -1,0 +1,82 @@
+import { TransferError } from "./errors";
+import { z } from "zod";
+import { consoleRecord } from "./import-files";
+import { type RecordEntry } from "./record";
+
+export async function importVictoriaLogs(
+  target: string,
+  records: AsyncIterable<RecordEntry>,
+) {
+  const base = new URL(target);
+
+  async function count() {
+    const response = await fetch(new URL("select/logsql/query", base), {
+      method: "POST",
+      body: new URLSearchParams({ query: "* | stats count() as total" }),
+      signal: AbortSignal.timeout(30_000),
+    });
+
+    if (!response.ok) {
+      throw new TransferError("VictoriaLogs count request failed.");
+    }
+
+    const text = (await response.text()).trim();
+    return text
+      ? z.object({ total: z.coerce.number() }).parse(JSON.parse(text)).total
+      : 0;
+  }
+
+  if ((await count()) !== 0) {
+    throw new TransferError("VictoriaLogs destination must be empty.");
+  }
+
+  let inserted = 0;
+  let batch: string[] = [];
+
+  async function flush() {
+    if (batch.length === 0) {
+      return;
+    }
+
+    const url = new URL("insert/jsonline", base);
+    url.searchParams.set("_time_field", "time");
+    url.searchParams.set("_msg_field", "msg");
+    const response = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/stream+json" },
+      body: batch.join("\n") + "\n",
+      signal: AbortSignal.timeout(30_000),
+    });
+
+    if (!response.ok) {
+      throw new TransferError(
+        "VictoriaLogs import failed. Discard this partial test destination before retrying.",
+      );
+    }
+
+    inserted += batch.length;
+    batch = [];
+  }
+
+  for await (const record of records) {
+    batch.push(JSON.stringify(consoleRecord(record)));
+
+    if (batch.length === 500) {
+      await flush();
+    }
+  }
+
+  await flush();
+  const deadline = Date.now() + 15_000;
+
+  while (Date.now() < deadline) {
+    if ((await count()) === inserted) {
+      return { count: inserted };
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+
+  throw new TransferError(
+    "VictoriaLogs count differs from the import. Check retention and use a fresh destination before retrying.",
+  );
+}

--- a/scripts/log-data/import-victorialogs.ts
+++ b/scripts/log-data/import-victorialogs.ts
@@ -8,6 +8,9 @@ export async function importVictoriaLogs(
   records: AsyncIterable<RecordEntry>,
 ) {
   const base = new URL(target);
+  if (!base.pathname.endsWith("/")) {
+    base.pathname += "/";
+  }
 
   async function count() {
     const response = await fetch(new URL("select/logsql/query", base), {

--- a/scripts/log-data/mysql-pages.ts
+++ b/scripts/log-data/mysql-pages.ts
@@ -1,0 +1,21 @@
+export async function* mysqlPages<Row extends { id: number }>(
+  readPage: (afterId: number, limit: number) => Promise<Row[]>,
+  maximum = Infinity,
+) {
+  let afterId = 0;
+  let remaining = maximum;
+
+  while (remaining > 0) {
+    const rows = await readPage(afterId, Math.min(1000, remaining));
+
+    if (rows.length === 0) {
+      return;
+    }
+
+    for (const row of rows) {
+      yield row;
+      afterId = row.id;
+      remaining--;
+    }
+  }
+}

--- a/scripts/log-data/mysql-storage.ts
+++ b/scripts/log-data/mysql-storage.ts
@@ -1,0 +1,14 @@
+import { TransferError } from "./errors";
+import { type Connection } from "mysql2/promise";
+import { z } from "zod";
+
+export async function requireTransactionalTable(connection: Connection) {
+  const [rows] = await connection.query(
+    "SELECT ENGINE FROM information_schema.tables WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'log_entries'",
+  );
+  const engines = z.array(z.object({ ENGINE: z.string() })).parse(rows);
+
+  if (engines.length !== 1 || engines[0]?.ENGINE.toLowerCase() !== "innodb") {
+    throw new TransferError("The log_entries table must exist and use InnoDB.");
+  }
+}

--- a/scripts/log-data/mysql-storage.ts
+++ b/scripts/log-data/mysql-storage.ts
@@ -6,9 +6,11 @@ export async function requireTransactionalTable(connection: Connection) {
   const [rows] = await connection.query(
     "SELECT ENGINE FROM information_schema.tables WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'log_entries'",
   );
-  const engines = z.array(z.object({ ENGINE: z.string() })).parse(rows);
+  const engines = z
+    .array(z.object({ ENGINE: z.string().nullable() }))
+    .parse(rows);
 
-  if (engines.length !== 1 || engines[0]?.ENGINE.toLowerCase() !== "innodb") {
+  if (engines.length !== 1 || engines[0]?.ENGINE?.toLowerCase() !== "innodb") {
     throw new TransferError("The log_entries table must exist and use InnoDB.");
   }
 }

--- a/scripts/log-data/record.ts
+++ b/scripts/log-data/record.ts
@@ -1,0 +1,104 @@
+import { normalizeLogTimestamp } from "~/server/logs/timestamp";
+import { TransferError } from "./errors";
+import { createHash } from "node:crypto";
+import { z } from "zod";
+
+const columns = {
+  requestTs: "request_ts",
+  clientIp: "client_ip",
+  clientName: "client_name",
+  durationMs: "duration_ms",
+  reason: "reason",
+  responseType: "response_type",
+  questionType: "question_type",
+  questionName: "question_name",
+  effectiveTldp: "effective_tldp",
+  answer: "answer",
+  responseCode: "response_code",
+  hostname: "hostname",
+} as const;
+
+export const recordSchema = z.object({
+  requestTs: z.iso.datetime(),
+  clientIp: z.string().nullable(),
+  clientName: z.string().nullable(),
+  durationMs: z.number().int().nullable(),
+  reason: z.string().nullable(),
+  responseType: z.string().nullable(),
+  questionType: z.string().nullable(),
+  questionName: z.string().nullable(),
+  effectiveTldp: z.string().nullable(),
+  answer: z.string().nullable(),
+  responseCode: z.string().nullable(),
+  hostname: z.string().nullable(),
+});
+
+export type RecordEntry = z.infer<typeof recordSchema>;
+
+export function timestamp(value: unknown, offset = "+00:00") {
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  if (typeof value !== "string" || value.length === 0) {
+    throw new TransferError("A log record has no valid timestamp.");
+  }
+
+  const iso = value.replace(" ", "T");
+  const zoned = /(?:Z|[+-]\d\d(?::?\d\d)?)$/.test(iso)
+    ? iso
+    : `${iso}${offset}`;
+  const parsed = normalizeLogTimestamp(zoned);
+
+  if (!parsed) {
+    throw new TransferError("A log record has an invalid timestamp.");
+  }
+
+  return parsed;
+}
+
+export function databaseRecord(value: unknown, offset = "+00:00") {
+  const row = z.record(z.string(), z.unknown()).parse(value);
+  const fields = Object.fromEntries(
+    Object.entries(columns).map(([field, column]) => [field, row[column]]),
+  );
+
+  return recordSchema.parse({
+    ...fields,
+    requestTs: timestamp(fields.requestTs, offset),
+    durationMs: fields.durationMs === null ? null : Number(fields.durationMs),
+  });
+}
+
+export function fingerprint() {
+  let count = 0;
+  let sum = 0n;
+  const modulus = 1n << 256n;
+
+  return {
+    add(record: RecordEntry) {
+      const bytes = JSON.stringify(recordSchema.parse(record));
+      sum =
+        (sum +
+          BigInt(`0x${createHash("sha256").update(bytes).digest("hex")}`)) %
+        modulus;
+      count++;
+    },
+    result() {
+      return { count, fingerprint: sum.toString(16).padStart(64, "0") };
+    },
+  };
+}
+
+export function transformRecord(
+  record: RecordEntry,
+  options: { shiftMs: number; hostname?: string },
+): RecordEntry {
+  return {
+    ...record,
+    requestTs: new Date(
+      new Date(record.requestTs).getTime() + options.shiftMs,
+    ).toISOString(),
+    hostname: options.hostname ?? record.hostname,
+  };
+}

--- a/scripts/log-data/snapshot.ts
+++ b/scripts/log-data/snapshot.ts
@@ -1,0 +1,116 @@
+import { TransferError } from "./errors";
+import { createReadStream, createWriteStream } from "node:fs";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { createInterface } from "node:readline";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import { createGunzip, createGzip } from "node:zlib";
+import { z } from "zod";
+import { fingerprint, recordSchema, type RecordEntry } from "./record";
+
+const manifestSchema = z.object({
+  version: z.literal(1),
+  source: z.literal("mysql"),
+  sourceOffset: z.string(),
+  createdAt: z.iso.datetime(),
+  count: z.number().int().nonnegative(),
+  fingerprint: z.string().regex(/^[a-f0-9]{64}$/),
+  firstTimestamp: z.iso.datetime().nullable(),
+  lastTimestamp: z.iso.datetime().nullable(),
+});
+
+export async function writeSnapshot(
+  directory: string,
+  records: AsyncIterable<RecordEntry>,
+  sourceOffset: string,
+) {
+  await mkdir(directory, { mode: 0o700 });
+  const digest = fingerprint();
+  let firstTimestamp: string | null = null;
+  let lastTimestamp: string | null = null;
+
+  async function* lines() {
+    for await (const value of records) {
+      const record = recordSchema.parse(value);
+      digest.add(record);
+      firstTimestamp =
+        firstTimestamp === null || record.requestTs < firstTimestamp
+          ? record.requestTs
+          : firstTimestamp;
+      lastTimestamp =
+        lastTimestamp === null || record.requestTs > lastTimestamp
+          ? record.requestTs
+          : lastTimestamp;
+      yield `${JSON.stringify(record)}\n`;
+    }
+  }
+
+  await pipeline(
+    Readable.from(lines()),
+    createGzip(),
+    createWriteStream(join(directory, "records.jsonl.gz"), {
+      flags: "wx",
+      mode: 0o600,
+    }),
+  );
+
+  const manifest = manifestSchema.parse({
+    version: 1,
+    source: "mysql",
+    sourceOffset,
+    createdAt: new Date().toISOString(),
+    ...digest.result(),
+    firstTimestamp,
+    lastTimestamp,
+  });
+  await writeFile(
+    join(directory, "manifest.json"),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+    { flag: "wx", mode: 0o600 },
+  );
+
+  return manifest;
+}
+
+export async function* readSnapshot(directory: string) {
+  const input = createReadStream(join(directory, "records.jsonl.gz"));
+  const decompressed = createGunzip();
+  const completion = pipeline(input, decompressed);
+  void completion.catch(() => undefined);
+  const lines = createInterface({ input: decompressed, crlfDelay: Infinity });
+
+  try {
+    for await (const line of lines) {
+      yield recordSchema.parse(JSON.parse(line));
+    }
+    await completion;
+  } finally {
+    lines.close();
+    decompressed.destroy();
+    input.destroy();
+    await completion.catch(() => undefined);
+  }
+}
+
+export async function verifySnapshot(directory: string) {
+  const manifest = manifestSchema.parse(
+    JSON.parse(await readFile(join(directory, "manifest.json"), "utf8")),
+  );
+  const digest = fingerprint();
+
+  for await (const record of readSnapshot(directory)) {
+    digest.add(record);
+  }
+
+  const actual = digest.result();
+
+  if (
+    actual.count !== manifest.count ||
+    actual.fingerprint !== manifest.fingerprint
+  ) {
+    throw new TransferError("Snapshot contents do not match the manifest.");
+  }
+
+  return manifest;
+}

--- a/scripts/log-data/snapshot.ts
+++ b/scripts/log-data/snapshot.ts
@@ -20,19 +20,13 @@ const manifestSchema = z.object({
   lastTimestamp: z.iso.datetime().nullable(),
 });
 
-export async function writeSnapshot(
-  directory: string,
-  records: AsyncIterable<RecordEntry>,
-  sourceOffset: string,
-) {
-  await mkdir(directory, { mode: 0o700 });
+function snapshotSummary() {
   const digest = fingerprint();
   let firstTimestamp: string | null = null;
   let lastTimestamp: string | null = null;
 
-  async function* lines() {
-    for await (const value of records) {
-      const record = recordSchema.parse(value);
+  return {
+    add(record: RecordEntry) {
       digest.add(record);
       firstTimestamp =
         firstTimestamp === null || record.requestTs < firstTimestamp
@@ -42,6 +36,25 @@ export async function writeSnapshot(
         lastTimestamp === null || record.requestTs > lastTimestamp
           ? record.requestTs
           : lastTimestamp;
+    },
+    result() {
+      return { ...digest.result(), firstTimestamp, lastTimestamp };
+    },
+  };
+}
+
+export async function writeSnapshot(
+  directory: string,
+  records: AsyncIterable<RecordEntry>,
+  sourceOffset: string,
+) {
+  await mkdir(directory, { mode: 0o700 });
+  const digest = snapshotSummary();
+
+  async function* lines() {
+    for await (const value of records) {
+      const record = recordSchema.parse(value);
+      digest.add(record);
       yield `${JSON.stringify(record)}\n`;
     }
   }
@@ -61,8 +74,6 @@ export async function writeSnapshot(
     sourceOffset,
     createdAt: new Date().toISOString(),
     ...digest.result(),
-    firstTimestamp,
-    lastTimestamp,
   });
   await writeFile(
     join(directory, "manifest.json"),
@@ -97,7 +108,7 @@ export async function verifySnapshot(directory: string) {
   const manifest = manifestSchema.parse(
     JSON.parse(await readFile(join(directory, "manifest.json"), "utf8")),
   );
-  const digest = fingerprint();
+  const digest = snapshotSummary();
 
   for await (const record of readSnapshot(directory)) {
     digest.add(record);
@@ -107,7 +118,9 @@ export async function verifySnapshot(directory: string) {
 
   if (
     actual.count !== manifest.count ||
-    actual.fingerprint !== manifest.fingerprint
+    actual.fingerprint !== manifest.fingerprint ||
+    actual.firstTimestamp !== manifest.firstTimestamp ||
+    actual.lastTimestamp !== manifest.lastTimestamp
   ) {
     throw new TransferError("Snapshot contents do not match the manifest.");
   }


### PR DESCRIPTION
Adds a reusable CLI to export a consistent, read-only snapshot of a Blocky MySQL query log and import it into disposable MySQL, PostgreSQL/Timescale, SQLite, CSV, per-client CSV and VictoriaLogs fixtures. This lets provider tests use the same real records instead of unrelated generated datasets, which makes it easier to test other providers against real data.

MySQL only for now since thats what I personally use, but can be extended if needed

Imports reject populated SQL targets and verify the resulting data. The CLI documentation explains provider conversion losses and cleanup requirements for partial file or VictoriaLogs imports.

Validated with 14 transfer tests, including native Blocky-generated schemas and file formats. Static checks pass.

Part 2 of 7 in the multi-server stack. Review against `review/01-log-provider-foundation`.
