### PR TITLE
Combine query history across configured servers

### DIFF
--- a/src/server/api/demo-config.test.ts
+++ b/src/server/api/demo-config.test.ts
@@ -20,6 +20,7 @@ vi.mock("~/env", () => ({
 
 vi.mock("~/server/logs", () => ({
   createLogProvider: mocks.createLogProvider,
+  getLogCoordinator: async () => ({}),
 }));
 
 import { blockyRouter } from "~/server/api/routers/blocky";

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -1,3 +1,4 @@
+import { logsRouter } from "~/server/api/routers/logs";
 import { serversRouter } from "~/server/api/routers/servers";
 import { blockyRouter } from "~/server/api/routers/blocky";
 import { statsRouter } from "~/server/api/routers/stats";
@@ -10,6 +11,7 @@ import { createCallerFactory, createTRPCRouter } from "~/server/api/trpc";
  */
 export const appRouter = createTRPCRouter({
   servers: serversRouter,
+  logs: logsRouter,
   blocky: blockyRouter,
   stats: statsRouter,
 });

--- a/src/server/api/routers/logs.ts
+++ b/src/server/api/routers/logs.ts
@@ -1,0 +1,72 @@
+import { TRPCError } from "@trpc/server";
+import { z } from "zod";
+import { TIME_RANGES } from "~/lib/constants";
+import { createTRPCRouter, publicProcedure } from "~/server/api/trpc";
+
+const logProcedure = publicProcedure.use(({ ctx, next }) => {
+  if (!ctx.isDemoServiceAvailable("queryLogs")) {
+    throw new TRPCError({
+      code: "SERVICE_UNAVAILABLE",
+      message: "Query logs are unavailable.",
+    });
+  }
+  return next();
+});
+
+const scopeSchema = z.object({ serverIds: z.array(z.string()).min(1) });
+const rangeSchema = scopeSchema.extend({ range: z.enum(TIME_RANGES) });
+const filtersSchema = scopeSchema.extend({
+  search: z.string().optional(),
+  client: z.string().optional(),
+  questionType: z.string().optional(),
+  responseType: z.string().optional(),
+});
+
+export const logsRouter = createTRPCRouter({
+  rows: logProcedure
+    .input(
+      filtersSchema.extend({
+        limit: z.number().int().min(1).max(101).default(10),
+        offset: z.number().int().min(0).default(0),
+      }),
+    )
+    .query(({ ctx, input }) => ctx.logs.rows(input.serverIds, input)),
+  count: logProcedure
+    .input(filtersSchema)
+    .query(({ ctx, input }) => ctx.logs.count(input.serverIds, input)),
+  queriesOverTime: logProcedure
+    .input(
+      rangeSchema.extend({
+        domain: z.string().optional(),
+        client: z.string().optional(),
+      }),
+    )
+    .query(({ ctx, input }) => {
+      const { serverIds, ...options } = input;
+      return ctx.logs.queriesOverTime(serverIds, options);
+    }),
+  topList: logProcedure
+    .input(
+      rangeSchema.extend({
+        type: z.enum(["domains", "clients"]),
+        filter: z.enum(["all", "blocked"]).default("all"),
+        limit: z.number().int().min(1).max(100).default(10),
+        offset: z.number().int().min(0).default(0),
+      }),
+    )
+    .query(({ ctx, input }) => ctx.logs.topList(input.serverIds, input)),
+  search: logProcedure
+    .input(
+      rangeSchema.extend({
+        type: z.enum(["domains", "clients"]),
+        query: z.string().min(1),
+        limit: z.number().int().min(1).max(50).default(10),
+      }),
+    )
+    .query(({ ctx, input }) => ctx.logs.search(input.serverIds, input)),
+  queryTypes: logProcedure
+    .input(rangeSchema)
+    .query(({ ctx, input }) =>
+      ctx.logs.queryTypes(input.serverIds, input.range),
+    ),
+});

--- a/src/server/api/trpc.ts
+++ b/src/server/api/trpc.ts
@@ -12,7 +12,7 @@ import { initTRPC } from "@trpc/server";
 import superjson from "superjson";
 import { ZodError, z } from "zod";
 
-import { createLogProvider } from "~/server/logs";
+import { createLogProvider, getLogCoordinator } from "~/server/logs";
 import { env } from "~/env";
 import {
   DEFAULT_DEMO_CONFIGURATION,
@@ -46,6 +46,7 @@ export const createTRPCContext = async (opts: { headers: Headers }) => {
 
   return {
     configuration,
+    logs: await getLogCoordinator(),
     servers: createBlockyServers(configuration),
     isDemoServiceAvailable,
     logProvider,

--- a/src/server/logs/__tests__/merged-pagination.test.ts
+++ b/src/server/logs/__tests__/merged-pagination.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, expect, it } from "vitest";
+import { rm } from "node:fs/promises";
+import { createLogCoordinator } from "~/server/logs/coordinator";
+import { parseConfiguration } from "~/server/config/schema";
+import { makeEntry, setupCsv, setupPostgres } from "./setup";
+
+const cleanup: (() => Promise<unknown>)[] = [];
+
+afterEach(async () => {
+  for (const close of cleanup.splice(0).reverse()) {
+    await close();
+  }
+});
+
+it.each(["csv", "postgres"] as const)(
+  "paginates every event once with out-of-order %s timestamps",
+  async (type) => {
+    const latest = makeEntry({
+      requestTs: "2026-09-10T12:00:03.000Z",
+      questionName: "latest.test",
+    });
+    const oldest = makeEntry({
+      requestTs: type === "postgres" ? null : "2026-09-10T12:00:01.000Z",
+      questionName: "oldest.test",
+    });
+    const first =
+      type === "postgres"
+        ? await setupPostgres([latest, oldest])
+        : setupCsv([latest, oldest]);
+
+    cleanup.push(async () => {
+      if ("container" in first) {
+        await first.provider.close();
+        await first.container.stop();
+      } else {
+        await rm(first.directory, { recursive: true, force: true });
+      }
+    });
+
+    const second = setupCsv([
+      makeEntry({
+        requestTs: "2026-09-10T12:00:02.000Z",
+        questionName: "middle.test",
+      }),
+    ]);
+
+    cleanup.push(() => rm(second.directory, { recursive: true, force: true }));
+
+    const configuration = parseConfiguration({
+      servers: {
+        a: { url: "http://a", logs: { source: "a" } },
+        b: { url: "http://b", logs: { source: "b" } },
+      },
+      logSources: {
+        a: { type: "csv", target: "a" },
+        b: { type: "csv", target: "b" },
+      },
+    });
+    const coordinator = createLogCoordinator(configuration, async (source) =>
+      source.target === "a" ? first.provider : second.provider,
+    );
+    const names: (string | null)[] = [];
+
+    for (let offset = 0; offset < 3; offset++) {
+      const page = await coordinator.rows(["a", "b"], { offset, limit: 1 });
+      expect(page.diagnostics).toEqual([]);
+      expect(page.items).toHaveLength(1);
+      names.push(...page.items.map((item) => item.questionName));
+    }
+
+    expect(names).toEqual(["latest.test", "middle.test", "oldest.test"]);
+  },
+  60_000,
+);

--- a/src/server/logs/__tests__/merged-pagination.test.ts
+++ b/src/server/logs/__tests__/merged-pagination.test.ts
@@ -72,3 +72,52 @@ it.each(["csv", "postgres"] as const)(
   },
   60_000,
 );
+
+it("keeps SQL timestamp ties stable across deep merged pages", async () => {
+  const fixtures = await Promise.all(
+    ["a", "b"].map((source) =>
+      setupPostgres(
+        Array.from({ length: 400 }, (_, index) =>
+          makeEntry({
+            requestTs: "2026-09-10T12:00:00.000Z",
+            questionName: `${source}-${String(index).padStart(3, "0")}.test`,
+          }),
+        ),
+      ),
+    ),
+  );
+  for (const fixture of fixtures) {
+    cleanup.push(async () => {
+      await fixture.provider.close();
+      await fixture.container.stop();
+    });
+  }
+  const configuration = parseConfiguration({
+    servers: {
+      a: { url: "http://a", logs: { source: "a" } },
+      b: { url: "http://b", logs: { source: "b" } },
+    },
+    logSources: {
+      a: { type: "csv", target: "a" },
+      b: { type: "csv", target: "b" },
+    },
+  });
+  const coordinator = createLogCoordinator(configuration, async (source) => {
+    const fixture = fixtures[source.target === "a" ? 0 : 1];
+    if (!fixture) {
+      throw new Error("Missing SQL fixture");
+    }
+    return fixture.provider;
+  });
+  const complete = await coordinator.rows(["a", "b"], {
+    offset: 0,
+    limit: 800,
+  });
+  expect(complete.items).toHaveLength(800);
+
+  for (const offset of [256, 257, 350, 395, 400, 401, 600, 790]) {
+    const page = await coordinator.rows(["a", "b"], { offset, limit: 20 });
+    expect(page.diagnostics).toEqual([]);
+    expect(page.items).toEqual(complete.items.slice(offset, offset + 20));
+  }
+}, 60_000);

--- a/src/server/logs/__tests__/provider-conformance.test.ts
+++ b/src/server/logs/__tests__/provider-conformance.test.ts
@@ -1,6 +1,9 @@
-import { beforeAll, afterAll, describe, it, expect } from "vitest";
+import { createLogCoordinator } from "~/server/logs/coordinator";
+import { parseConfiguration } from "~/server/config/schema";
+import { beforeAll, afterAll, describe, it, expect, vi } from "vitest";
 import { type LogEntry, type LogProvider } from "~/server/logs/types";
 import { getTimeRangeConfig } from "~/server/logs/aggregation-utils";
+import { normalizeLogTimestamp } from "~/server/logs/timestamp";
 import { setupProviders } from "./setup";
 import { countEntriesInRange } from "./seed-data";
 
@@ -58,7 +61,162 @@ function defineProviderTests(providerName: string) {
       provider = p;
     });
 
+    it("searches provider rankings through the coordinator", async () => {
+      const configuration = parseConfiguration({
+        servers: { test: { url: "http://test", logs: { source: "test" } } },
+        logSources: { test: { type: "csv", target: "test" } },
+      });
+      const logs = createLogCoordinator(configuration, async () => provider);
+
+      for (const type of ["domains", "clients"] as const) {
+        const query = type === "domains" ? "GOOGLE.COM" : "LAP";
+        const result = await logs.search(["test"], {
+          type,
+          range: "30d",
+          query,
+          limit: 1,
+        });
+        const matching = entriesInRange("30d").filter((entry) =>
+          (type === "domains" ? entry.questionName : entry.clientName)
+            ?.toLowerCase()
+            .includes(query.toLowerCase()),
+        );
+
+        expect(result.diagnostics).toEqual([]);
+        expect(result.items).toHaveLength(1);
+        expect(result.items[0]?.count).toBe(matching.length);
+      }
+
+      expect(
+        (
+          await logs.search(["test"], {
+            type: "domains",
+            range: "30d",
+            query: "not-present.invalid",
+            limit: 10,
+          })
+        ).items,
+      ).toEqual([]);
+    });
+
+    it("excludes known hostnames while retaining unknown logs across rows and aggregates", async () => {
+      const scope = { excludedHostnames: ["blocky-instance-1"] };
+      const expected = seedData.filter(
+        (entry) => entry.hostname !== "blocky-instance-1",
+      );
+      const recent = entriesInRange("24h").filter(
+        (entry) => entry.hostname !== "blocky-instance-1",
+      );
+      const [rows, count, chart, domains, clients, types] = await Promise.all([
+        provider.getQueryLogRows({ ...scope, limit: 100, offset: 0 }),
+        provider.getQueryLogCount(scope),
+        provider.getQueriesOverTime({ ...scope, range: "24h" }),
+        provider.getTopDomains({
+          ...scope,
+          range: "24h",
+          offset: 0,
+          filter: "all",
+        }),
+        provider.getTopClients({
+          ...scope,
+          range: "24h",
+          offset: 0,
+          filter: "all",
+        }),
+        provider.getQueryTypesBreakdown("24h", scope),
+      ]);
+      expect(count).toBe(expected.length);
+      expect(rows).toHaveLength(expected.length);
+      expect(rows.some((entry) => entry.hostname === null)).toBe(true);
+      expect(
+        rows.every((entry) => entry.hostname !== "blocky-instance-1"),
+      ).toBe(true);
+      expect(chart.reduce((sum, bucket) => sum + bucket.total, 0)).toBe(
+        recent.length,
+      );
+      expect(domains.items.reduce((sum, item) => sum + item.count, 0)).toBe(
+        recent.length,
+      );
+      expect(clients.items.reduce((sum, item) => sum + item.total, 0)).toBe(
+        recent.length,
+      );
+      expect(types.reduce((sum, item) => sum + item.count, 0)).toBe(
+        recent.length,
+      );
+      expect(await provider.getQueryLogCount({})).toBe(seedData.length);
+    });
+
     describe("getQueryLogs", () => {
+      it("applies an ID boundary to both row reads and counts", async () => {
+        const snapshot = await provider.getQueryLogSnapshot?.();
+
+        if (snapshot === undefined) {
+          return;
+        }
+
+        const all = await provider.getQueryLogRows({
+          offset: 0,
+          limit: seedData.length,
+        });
+        const maxId = Math.floor(snapshot / 2);
+        const expected = all.filter((row) => (row.id ?? 0) <= maxId);
+        const [rows, count] = await Promise.all([
+          provider.getQueryLogRows({ maxId, offset: 2, limit: 5 }),
+          provider.getQueryLogCount({ maxId }),
+        ]);
+
+        expect(rows).toEqual(expected.slice(2, 7));
+        expect(count).toBe(expected.length);
+      });
+
+      it("counts scoped records at inclusive timestamp boundaries for indexed pagination", async () => {
+        if (!provider.getQueryLogCountSince) {
+          return;
+        }
+
+        const filters = {
+          excludedHostnames: ["blocky-instance-1"],
+          questionType: "A",
+        };
+        const rows = await provider.getQueryLogRows({
+          ...filters,
+          offset: 0,
+          limit: seedData.length,
+        });
+
+        for (const row of rows.slice(0, 5)) {
+          const timestamp = new Date(
+            normalizeLogTimestamp(row.requestTs) ?? 0,
+          ).getTime();
+
+          for (const delta of [0, 1]) {
+            const since = new Date(timestamp + delta);
+            const count = await provider.getQueryLogCountSince(filters, since);
+
+            expect(count).toBe(
+              rows.filter(
+                (entry) =>
+                  new Date(normalizeLogTimestamp(entry.requestTs) ?? 0) >=
+                  since,
+              ).length,
+            );
+          }
+        }
+      });
+
+      it.each(['"', "\\", "[", "|"])(
+        "treats %s as literal search text",
+        async (search) => {
+          const result = await provider.getQueryLogs({
+            limit: 10,
+            offset: 0,
+            search,
+          });
+          expect(result.totalCount).toBe(0);
+          expect(result.items).toEqual([]);
+        },
+      );
+
       it("returns all entries with correct totalCount", async () => {
         const result = await provider.getQueryLogs({ limit: 100, offset: 0 });
         expect(result.totalCount).toBe(seedData.length);
@@ -201,15 +359,6 @@ function defineProviderTests(providerName: string) {
         for (const item of result.items) {
           expect(item.clientName).not.toBeNull();
         }
-      });
-    });
-
-    describe("getStats24h", () => {
-      it("returns correct totalQueries and blocked", async () => {
-        const expected = countEntriesInRange(seedData, "24h");
-        const result = await provider.getStats24h();
-        expect(result.totalQueries).toBe(expected.total);
-        expect(result.blocked).toBe(expected.blocked);
       });
     });
 
@@ -663,108 +812,6 @@ function defineProviderTests(providerName: string) {
         expect(totalPercentage).toBeCloseTo(100, 0);
       });
     });
-
-    describe("searchDomains", () => {
-      it("partial match with correct count", async () => {
-        const result = await provider.searchDomains({
-          range: "30d",
-          query: "google",
-          limit: 10,
-        });
-        const googleEntry = result.find((r) => r.domain === "google.com");
-        expect(googleEntry).toBeDefined();
-        const expectedCount = entriesInRange("30d").filter(
-          (e) => e.questionName === "google.com",
-        ).length;
-        expect(googleEntry?.count).toBe(expectedCount);
-      });
-
-      it("case-insensitive", async () => {
-        const result = await provider.searchDomains({
-          range: "30d",
-          query: "GITHUB",
-          limit: 10,
-        });
-        const domains = result.map((r) => r.domain);
-        expect(domains).toContain("GitHub.com");
-      });
-
-      it("respects limit", async () => {
-        const result = await provider.searchDomains({
-          range: "30d",
-          query: "o",
-          limit: 2,
-        });
-        expect(result.length).toBeLessThanOrEqual(2);
-      });
-
-      it("query containing a dot must not produce backslash sequences that break VictoriaLogs", async () => {
-        const result = await provider.searchDomains({
-          range: "30d",
-          query: "google.com",
-          limit: 10,
-        });
-        const googleEntry = result.find((r) => r.domain === "google.com");
-        expect(googleEntry).toBeDefined();
-        const expectedCount = entriesInRange("30d").filter(
-          (e) => e.questionName === "google.com",
-        ).length;
-        expect(googleEntry?.count).toBe(expectedCount);
-      });
-
-      it("empty query returns empty array", async () => {
-        const result = await provider.searchDomains({
-          range: "30d",
-          query: "",
-          limit: 10,
-        });
-        expect(result).toHaveLength(0);
-      });
-    });
-
-    describe("searchClients", () => {
-      it("partial match with correct count", async () => {
-        const result = await provider.searchClients({
-          range: "30d",
-          query: "lap",
-          limit: 10,
-        });
-        const laptopEntry = result.find((r) => r.client === "laptop");
-        expect(laptopEntry).toBeDefined();
-        const expectedCount = entriesInRange("30d").filter(
-          (e) => e.clientName === "laptop",
-        ).length;
-        expect(laptopEntry?.count).toBe(expectedCount);
-      });
-
-      it("case-insensitive", async () => {
-        const result = await provider.searchClients({
-          range: "30d",
-          query: "PHONE",
-          limit: 10,
-        });
-        const clients = result.map((r) => r.client);
-        expect(clients).toContain("Phone");
-      });
-
-      it("respects limit", async () => {
-        const result = await provider.searchClients({
-          range: "30d",
-          query: "e",
-          limit: 1,
-        });
-        expect(result.length).toBeLessThanOrEqual(1);
-      });
-
-      it("empty query returns empty array", async () => {
-        const result = await provider.searchClients({
-          range: "30d",
-          query: "",
-          limit: 10,
-        });
-        expect(result).toHaveLength(0);
-      });
-    });
   });
 }
 
@@ -776,6 +823,23 @@ defineProviderTests("csv-client");
 defineProviderTests("victorialogs");
 
 describe("cross-provider consistency", () => {
+  it("aligns chart buckets and counts across database, file, and console sources", async () => {
+    const clock = vi.spyOn(Date, "now").mockReturnValue(Date.now());
+    try {
+      const charts = await Promise.all(
+        [...providers.values()].map((provider) =>
+          provider.getQueriesOverTime({ range: "24h" }),
+        ),
+      );
+      const baseline = charts[0];
+      for (const chart of charts.slice(1)) {
+        expect(chart).toEqual(baseline);
+      }
+    } finally {
+      clock.mockRestore();
+    }
+  });
+
   const providerNames = [
     "mysql",
     "postgres",
@@ -898,15 +962,6 @@ describe("cross-provider consistency", () => {
     });
   });
 
-  it("getStats24h returns identical results across all providers", async () => {
-    const results = await queryAllProviders((p) => p.getStats24h());
-
-    compareAcrossProviders(results, (baseline, current) => {
-      expect(current.totalQueries).toBe(baseline.totalQueries);
-      expect(current.blocked).toBe(baseline.blocked);
-    });
-  });
-
   it("getQueriesOverTime totals match across all providers", async () => {
     for (const range of ["1h", "24h", "7d", "30d"] as const) {
       const results = await queryAllProviders((p) =>
@@ -927,40 +982,6 @@ describe("cross-provider consistency", () => {
         expect(currentTotals.total).toBe(baselineTotals.total);
         expect(currentTotals.blocked).toBe(baselineTotals.blocked);
         expect(currentTotals.cached).toBe(baselineTotals.cached);
-      });
-    }
-  });
-
-  it("searchDomains returns identical results across all providers", async () => {
-    for (const query of ["google", "blocked", "GITHUB", "google.com"]) {
-      const results = await queryAllProviders((p) =>
-        p.searchDomains({ range: "30d", query, limit: 100 }),
-      );
-
-      compareAcrossProviders(results, (baseline, current) => {
-        expect(current.map((e) => e.domain)).toEqual(
-          baseline.map((e) => e.domain),
-        );
-        for (let j = 0; j < baseline.length; j++) {
-          expect(current[j]?.count).toBe(baseline[j]?.count);
-        }
-      });
-    }
-  });
-
-  it("searchClients returns identical results across all providers", async () => {
-    for (const query of ["lap", "Phone", "server"]) {
-      const results = await queryAllProviders((p) =>
-        p.searchClients({ range: "30d", query, limit: 100 }),
-      );
-
-      compareAcrossProviders(results, (baseline, current) => {
-        expect(current.map((e) => e.client)).toEqual(
-          baseline.map((e) => e.client),
-        );
-        for (let j = 0; j < baseline.length; j++) {
-          expect(current[j]?.count).toBe(baseline[j]?.count);
-        }
       });
     }
   });

--- a/src/server/logs/__tests__/setup.ts
+++ b/src/server/logs/__tests__/setup.ts
@@ -283,7 +283,7 @@ function setupSqlite(entries: LogEntry[]): {
   return { provider, filePath };
 }
 
-function setupCsv(entries: LogEntry[]): {
+export function setupCsv(entries: LogEntry[]): {
   provider: CsvLogProvider;
   directory: string;
 } {
@@ -353,6 +353,7 @@ async function setupVictoriaLogs(entries: LogEntry[]): Promise<{
         client_names: entry.clientName ?? "",
         duration_ms: entry.durationMs != null ? String(entry.durationMs) : "",
         response_reason: entry.reason ?? "",
+        instance: entry.hostname ?? "",
         question_name: entry.questionName ?? "",
         answer: entry.answer ?? "",
         response_code: entry.responseCode ?? "",

--- a/src/server/logs/coordinator.test.ts
+++ b/src/server/logs/coordinator.test.ts
@@ -1,0 +1,432 @@
+import { describe, expect, it, vi } from "vitest";
+import { BaseMemoryLogProvider } from "~/server/logs/base-provider";
+import { createFilterFn } from "~/server/logs/csv/utils";
+import { createLogCoordinator } from "~/server/logs/coordinator";
+import { parseConfiguration } from "~/server/config/schema";
+import {
+  type LogEntry,
+  type QueryLogFilters,
+  type QueryLogsOptions,
+} from "~/server/logs/types";
+
+function entry(
+  questionName: string,
+  hostname: string | null,
+  id: number,
+): LogEntry {
+  return {
+    id,
+    hostname,
+    questionName,
+    requestTs: new Date(Date.now() - 60_000 - id * 1000).toISOString(),
+    clientIp: "127.0.0.1",
+    clientName: "laptop",
+    durationMs: 1,
+    reason: "RESOLVED",
+    answer: "127.0.0.1",
+    responseCode: "NOERROR",
+    responseType: "RESOLVED",
+    questionType: "A",
+    effectiveTldp: null,
+  };
+}
+
+class MemorySource extends BaseMemoryLogProvider {
+  constructor(private readonly entries: LogEntry[]) {
+    super();
+  }
+  async getQueryLogs(options: QueryLogsOptions) {
+    const filtered = this.entries.filter(createFilterFn(options));
+    return {
+      items: filtered.slice(options.offset, options.offset + options.limit),
+      totalCount: filtered.length,
+    };
+  }
+  protected async fetchEntriesInRange() {
+    return this.entries;
+  }
+}
+
+describe("multi-source query logs", () => {
+  it("keeps a deep page stable when new rows arrive during the seek", async () => {
+    const records = {
+      a: Array.from({ length: 1000 }, (_, index) =>
+        entry("a", null, index * 2),
+      ),
+      b: Array.from({ length: 1000 }, (_, index) =>
+        entry("b", null, index * 2 + 1),
+      ),
+    };
+    let inserted = false;
+
+    class SnapshotSource extends MemorySource {
+      constructor(private readonly rows: LogEntry[]) {
+        super(rows);
+      }
+
+      async getQueryLogSnapshot() {
+        return Math.max(...this.rows.map((row) => row.id ?? 0));
+      }
+
+      private visible(filters: QueryLogFilters) {
+        return this.rows.filter(
+          (row) =>
+            filters.maxId === undefined || (row.id ?? 0) <= filters.maxId,
+        );
+      }
+
+      async getQueryLogRows(options: QueryLogsOptions) {
+        return this.visible(options).slice(
+          options.offset,
+          options.offset + options.limit,
+        );
+      }
+
+      async getQueryLogCountSince(filters: QueryLogFilters, since: Date) {
+        if (!inserted) {
+          inserted = true;
+          records.a.unshift(
+            ...Array.from({ length: 100 }, (_, index) => ({
+              ...entry("new", null, 10_000 + index),
+              requestTs: new Date().toISOString(),
+            })),
+          );
+        }
+
+        return this.visible(filters).filter(
+          (row) => new Date(row.requestTs ?? 0) >= since,
+        ).length;
+      }
+    }
+
+    const configuration = parseConfiguration({
+      servers: {
+        a: { url: "http://a", logs: { source: "a" } },
+        b: { url: "http://b", logs: { source: "b" } },
+      },
+      logSources: {
+        a: { type: "csv", target: "a" },
+        b: { type: "csv", target: "b" },
+      },
+    });
+    const logs = createLogCoordinator(
+      configuration,
+      async (source) =>
+        new SnapshotSource(source.target === "a" ? records.a : records.b),
+    );
+    const result = await logs.rows(["a", "b"], { offset: 600, limit: 11 });
+
+    expect(inserted).toBe(true);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.items.map((row) => row.id)).toEqual(
+      Array.from({ length: 11 }, (_, index) => 600 + index),
+    );
+  });
+
+  it("reuses a large ranking when navigating to an uncached page", async () => {
+    const configuration = parseConfiguration({
+      servers: { a: { url: "http://a", logs: { source: "a" } } },
+      logSources: { a: { type: "csv", target: "a" } },
+    });
+    const provider = new MemorySource([]);
+    const groups = vi
+      .spyOn(provider, "getTopDomains")
+      .mockImplementation(async () => ({
+        totalCount: 250_000,
+        items: Array.from({ length: 250_000 }, (_, index) => ({
+          domain: `domain-${index}.${"long-domain-name".repeat(4)}`,
+          count: 250_000 - index,
+          blocked: 0,
+          percentage: 0,
+        })),
+      }));
+    const logs = createLogCoordinator(configuration, async () => provider);
+    const options = {
+      type: "domains",
+      range: "30d",
+      filter: "all",
+      offset: 0,
+      limit: 10,
+    } as const;
+
+    await logs.topList(["a"], options);
+    const page = await logs.topList(["a"], { ...options, offset: 150_000 });
+
+    expect(page.totalCount).toBe(250_000);
+    expect(page.items[0]?.count).toBe(100_000);
+    expect(groups).toHaveBeenCalledTimes(1);
+  });
+
+  it("locates a deep page without loading the preceding rows", async () => {
+    const size = 3_500_000;
+    const configuration = parseConfiguration({
+      servers: {
+        a: { url: "http://a", logs: { source: "a" } },
+        b: { url: "http://b", logs: { source: "b" } },
+      },
+      logSources: {
+        a: { type: "csv", target: "a" },
+        b: { type: "csv", target: "b" },
+      },
+    });
+    let transferred = 0;
+    const logs = createLogCoordinator(configuration, async (source) => {
+      const provider = new MemorySource([]);
+      vi.spyOn(provider, "getQueryLogCount").mockResolvedValue(size);
+      vi.spyOn(provider, "getQueryLogRows").mockImplementation(
+        async (options) => {
+          if (options.limit > 256) {
+            throw new Error("Unbounded row allocation");
+          }
+
+          const length = Math.max(
+            0,
+            Math.min(options.limit, size - options.offset),
+          );
+          transferred += length;
+
+          return Array.from({ length }, (_, index) =>
+            entry(
+              "virtual",
+              null,
+              (options.offset + index) * 2 + (source.target === "a" ? 0 : 1),
+            ),
+          );
+        },
+      );
+
+      return provider;
+    });
+
+    const result = await logs.rows(["a", "b"], { offset: size, limit: 11 });
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.items.map((item) => item.id)).toEqual(
+      Array.from({ length: 11 }, (_, index) => size + index),
+    );
+    expect(transferred).toBeLessThan(1_000);
+  });
+
+  it("pages equal timestamps consistently across sources and selection order", async () => {
+    const timestamp = new Date().toISOString();
+    const configuration = parseConfiguration({
+      servers: {
+        a: { url: "http://a", logs: { source: "a" } },
+        b: { url: "http://b", logs: { source: "b" } },
+      },
+      logSources: {
+        a: { type: "csv", target: "a" },
+        b: { type: "csv", target: "b" },
+      },
+    });
+    const logs = createLogCoordinator(
+      configuration,
+      async () =>
+        new MemorySource(
+          Array.from({ length: 7 }, (_, id) => ({
+            ...entry("same", null, id),
+            requestTs: timestamp,
+          })),
+        ),
+    );
+    const collected: string[] = [];
+
+    for (let offset = 0; offset < 14; offset += 3) {
+      const page = await logs.rows(offset % 2 ? ["b", "a"] : ["a", "b"], {
+        limit: 3,
+        offset,
+      });
+      collected.push(
+        ...page.items.map((item) => `${item.sourceId}:${item.id}`),
+      );
+    }
+
+    expect(collected).toEqual(
+      ["a", "b"].flatMap((source) =>
+        Array.from({ length: 7 }, (_, id) => `${source}:${id}`),
+      ),
+    );
+    expect(new Set(collected).size).toBe(14);
+  });
+
+  it("restarts page selection over healthy sources after a read fails mid-page", async () => {
+    const configuration = parseConfiguration({
+      servers: {
+        a: { url: "http://a", logs: { source: "a" } },
+        b: { url: "http://b", logs: { source: "b" } },
+      },
+      logSources: {
+        a: { type: "csv", target: "a" },
+        b: { type: "csv", target: "b" },
+      },
+    });
+    const healthy = new MemorySource(
+      Array.from({ length: 1000 }, (_, index) => entry("a", null, index * 2)),
+    );
+    const failing = new MemorySource(
+      Array.from({ length: 1000 }, (_, index) =>
+        entry("b", null, index * 2 + 1),
+      ),
+    );
+    const read = failing.getQueryLogRows.bind(failing);
+    let calls = 0;
+    vi.spyOn(failing, "getQueryLogRows").mockImplementation(async (options) => {
+      calls++;
+
+      if (calls === 2) {
+        throw new Error("Disconnected");
+      }
+
+      return read(options);
+    });
+    const logs = createLogCoordinator(configuration, async (source) =>
+      source.target === "a" ? healthy : failing,
+    );
+    const result = await logs.rows(["a", "b"], { offset: 600, limit: 11 });
+
+    expect(result.diagnostics).toEqual([
+      { sourceId: "b", message: "Unable to read this log source." },
+    ]);
+    expect(result.items.map((item) => item.id)).toEqual(
+      Array.from({ length: 11 }, (_, index) => (600 + index) * 2),
+    );
+  });
+
+  it("reads shared sources once and retains unknown records when every mapped owner is unselected", async () => {
+    const shared = new MemorySource([
+      entry("a", "host-a", 1),
+      entry("b", "host-b", 2),
+      entry("unknown", null, 3),
+    ]);
+    const dedicated = new MemorySource([entry("c", null, 4)]);
+    const sharedRows = vi.spyOn(shared, "getQueryLogRows");
+    const configuration = parseConfiguration({
+      servers: {
+        a: { url: "http://a", logs: { source: "shared", hostname: "host-a" } },
+        b: { url: "http://b", logs: { source: "shared", hostname: "host-b" } },
+        c: { url: "http://c", logs: { source: "dedicated" } },
+      },
+      logSources: {
+        shared: { type: "csv", target: "shared" },
+        dedicated: { type: "csv", target: "dedicated" },
+      },
+    });
+    const initialize = vi.fn(async (source: { target: string }) =>
+      source.target === "shared" ? shared : dedicated,
+    );
+    const logs = createLogCoordinator(configuration, initialize);
+    const all = await logs.rows(["a", "b", "c"], { limit: 10, offset: 0 });
+    expect(all.items.map((item) => item.serverId)).toEqual([
+      "a",
+      "b",
+      null,
+      "c",
+    ]);
+    expect(sharedRows).toHaveBeenCalledTimes(1);
+    const scoped = await logs.rows(["c"], { limit: 10, offset: 0 });
+    expect(scoped.items.map((item) => item.questionName)).toEqual([
+      "unknown",
+      "c",
+    ]);
+    expect(initialize).toHaveBeenCalledTimes(2);
+    expect((await logs.count(["c"], {})).totalCount).toBe(2);
+  });
+
+  it("merges before paging and ranks full groups, with counts cached independently of pages", async () => {
+    const a = new MemorySource([
+      ...Array.from({ length: 6 }, (_, i) => entry("a-only", null, i * 2)),
+      ...Array.from({ length: 5 }, (_, i) => entry("shared", null, 20 + i * 2)),
+    ]);
+    const b = new MemorySource([
+      ...Array.from({ length: 6 }, (_, i) => entry("b-only", null, i * 2 + 1)),
+      ...Array.from({ length: 5 }, (_, i) => entry("shared", null, 21 + i * 2)),
+    ]);
+    const counts = vi.spyOn(a, "getQueryLogCount");
+    const groups = vi.spyOn(a, "getTopDomains");
+    const configuration = parseConfiguration({
+      servers: {
+        a: { url: "http://a", logs: { source: "a" } },
+        b: { url: "http://b", logs: { source: "b" } },
+      },
+      logSources: {
+        a: { type: "csv", target: "a" },
+        b: { type: "csv", target: "b" },
+      },
+    });
+    const logs = createLogCoordinator(configuration, async (source) =>
+      source.target === "a" ? a : b,
+    );
+    const page = await logs.rows(["a", "b"], { limit: 3, offset: 3 });
+    expect(page.items.map((item) => item.id)).toEqual([3, 4, 5]);
+    expect(await logs.count(["a", "b"], {})).toMatchObject({ totalCount: 22 });
+    await logs.rows(["a", "b"], { limit: 3, offset: 6 });
+    await logs.count(["a", "b"], {});
+    expect(counts).toHaveBeenCalledTimes(1);
+    await logs.count(["a", "b"], { search: "shared" });
+    expect(counts).toHaveBeenCalledTimes(2);
+
+    const options = {
+      type: "domains",
+      range: "24h",
+      filter: "all",
+      limit: 1,
+      offset: 0,
+    } as const;
+    const first = await logs.topList(["a", "b"], options);
+    expect(first.items[0]).toMatchObject({ name: "shared", count: 10 });
+    expect(first.items[0]?.percentage).toBeCloseTo((10 / 22) * 100);
+    expect(first.totalCount).toBe(3);
+    await logs.topList(["b", "a"], { ...options, offset: 1 });
+    expect(groups).toHaveBeenCalledTimes(1);
+
+    const single = await logs.topList(["a"], options);
+    expect(single.items[0]).toMatchObject({ name: "a-only", count: 6 });
+    expect(groups).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps available results and retries a failed source initialization", async () => {
+    const available = new MemorySource([entry("available", null, 1)]);
+    const configuration = parseConfiguration({
+      servers: {
+        a: { url: "http://a", logs: { source: "a" } },
+        b: { url: "http://b", logs: { source: "b" } },
+      },
+      logSources: {
+        a: { type: "csv", target: "a" },
+        b: { type: "csv", target: "b" },
+      },
+    });
+    let offline = true;
+    const initialize = vi.fn(async (source: { target: string }) => {
+      if (source.target === "b" && offline) {
+        throw new Error("secret connection URI");
+      }
+      return available;
+    });
+    const logs = createLogCoordinator(configuration, initialize);
+    const result = await logs.rows(["a", "b"], { limit: 10, offset: 0 });
+    expect(result.items).toHaveLength(1);
+    expect(result.diagnostics).toEqual([
+      { sourceId: "b", message: "Unable to read this log source." },
+    ]);
+    expect(JSON.stringify(result)).not.toContain("secret");
+    const options = {
+      type: "domains",
+      range: "24h",
+      filter: "all",
+      limit: 10,
+      offset: 0,
+    } as const;
+    expect((await logs.topList(["a", "b"], options)).diagnostics).toHaveLength(
+      1,
+    );
+
+    offline = false;
+    expect((await logs.topList(["a", "b"], options)).diagnostics).toEqual([]);
+
+    expect(
+      (await logs.rows(["a", "b"], { limit: 10, offset: 0 })).diagnostics,
+    ).toEqual([]);
+    expect(initialize).toHaveBeenCalledTimes(4);
+  });
+});

--- a/src/server/logs/coordinator.ts
+++ b/src/server/logs/coordinator.ts
@@ -1,0 +1,345 @@
+import { type Configuration } from "~/server/config/schema";
+import { type TimeRange } from "~/lib/constants";
+import { createLogSources } from "~/server/logs/sources";
+import { createResultCache } from "~/server/logs/result-cache";
+import { mapConcurrent } from "~/server/utils/map-concurrent";
+import { MAX_PREFIX_ROWS, mergePage } from "~/server/logs/merge-page";
+import { createRankedResults } from "~/server/logs/ranked-results";
+import {
+  type LogProvider,
+  type QueryLogFilters,
+  type QueryLogsOptions,
+} from "~/server/logs/types";
+
+type RankedEntry = { name: string; count: number; blocked: number };
+
+function rank(groups: RankedEntry[][]) {
+  const merged = new Map<string, RankedEntry>();
+  for (const group of groups) {
+    for (const entry of group) {
+      const existing = merged.get(entry.name);
+      merged.set(entry.name, {
+        name: entry.name,
+        count: entry.count + (existing?.count ?? 0),
+        blocked: entry.blocked + (existing?.blocked ?? 0),
+      });
+    }
+  }
+  const items = [...merged.values()];
+  const total = items.reduce((sum, item) => sum + item.count, 0);
+  return items
+    .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name))
+    .map((item) => ({
+      ...item,
+      percentage: total ? (item.count / total) * 100 : 0,
+    }));
+}
+
+export function createLogCoordinator(
+  configuration: Configuration,
+  initialize?: Parameters<typeof createLogSources>[1],
+) {
+  const sources = createLogSources(configuration, initialize);
+  const counts = createResultCache<number>({ ttlMs: 30_000, maxEntries: 100 });
+  const rankings = createResultCache<{
+    results: Awaited<ReturnType<typeof createRankedResults>>;
+    diagnostics: { sourceId: string; message: string }[];
+  }>({
+    ttlMs: 30_000,
+    maxEntries: 20,
+    maxWeight: 32 * 1024 * 1024,
+    weightOf: ({ results }) => results.bytes,
+    shouldCache: ({ diagnostics }) => diagnostics.length === 0,
+  });
+  const charts = createResultCache<
+    Awaited<ReturnType<LogProvider["getQueriesOverTime"]>>
+  >({
+    ttlMs: 30_000,
+    maxEntries: 40,
+  });
+
+  async function run<T>(
+    ids: string[],
+    read: (
+      source: ReturnType<typeof sources.select>[number],
+      provider: LogProvider,
+    ) => Promise<T>,
+  ) {
+    const results = await mapConcurrent(
+      sources.select(ids),
+      4,
+      async (source) => {
+        try {
+          return {
+            success: true,
+            value: await read(source, await source.provider()),
+          } as const;
+        } catch {
+          return {
+            success: false,
+            sourceId: source.id,
+            message: "Unable to read this log source.",
+          } as const;
+        }
+      },
+    );
+    return {
+      values: results.flatMap((result) =>
+        result.success ? [result.value] : [],
+      ),
+      diagnostics: results.flatMap((result) =>
+        result.success
+          ? []
+          : [
+              {
+                sourceId: result.sourceId,
+                message: result.message,
+              },
+            ],
+      ),
+    };
+  }
+
+  async function ranking(
+    ids: string[],
+    options: {
+      type: "domains" | "clients";
+      range: TimeRange;
+      filter: "all" | "blocked";
+    },
+  ) {
+    const scope = sources
+      .select(ids)
+      .map((source) => [source.id, source.scope]);
+    const key = JSON.stringify([
+      scope,
+      options.type,
+      options.range,
+      options.filter,
+    ]);
+    return rankings.get(key, async () => {
+      const result = await run(ids, async (source, provider) => {
+        const scoped = {
+          ...source.scope,
+          range: options.range,
+          filter: options.filter,
+          offset: 0,
+        };
+
+        if (options.type === "domains") {
+          return (await provider.getTopDomains(scoped)).items.map((item) => ({
+            name: item.domain,
+            count: item.count,
+            blocked: item.blocked,
+          }));
+        }
+
+        return (await provider.getTopClients(scoped)).items.map((item) => ({
+          name: item.client,
+          count: item.total,
+          blocked: item.blocked,
+        }));
+      });
+
+      return {
+        results: await createRankedResults(rank(result.values)),
+        diagnostics: result.diagnostics,
+      };
+    });
+  }
+
+  return {
+    async rows(ids: string[], options: QueryLogsOptions) {
+      const snapshot =
+        options.offset > MAX_PREFIX_ROWS && sources.select(ids).length > 1;
+      const result = await run(ids, async (source, provider) => ({
+        source,
+        provider,
+        maxId: snapshot ? await provider.getQueryLogSnapshot?.() : undefined,
+      }));
+      const failed = new Set<string>();
+
+      for (;;) {
+        const previousFailures = failed.size;
+        const readers = result.values
+          .filter(({ source }) => !failed.has(source.id))
+          .map(({ source, provider, maxId }) => {
+            const scoped = { ...options, ...source.scope, maxId };
+            const countSince = provider.getQueryLogCountSince?.bind(provider);
+
+            async function read<T>(operation: () => Promise<T>, fallback: T) {
+              if (failed.has(source.id)) {
+                return fallback;
+              }
+
+              try {
+                return await operation();
+              } catch {
+                if (!failed.has(source.id)) {
+                  failed.add(source.id);
+                  result.diagnostics.push({
+                    sourceId: source.id,
+                    message: "Unable to read this log source.",
+                  });
+                }
+
+                return fallback;
+              }
+            }
+
+            return {
+              countBefore: countSince
+                ? (pivot: ReturnType<typeof source.identify>) =>
+                    read(
+                      () =>
+                        countSince(
+                          scoped,
+                          new Date(
+                            new Date(pivot.requestTs ?? 0).getTime() +
+                              (source.id.localeCompare(pivot.sourceId) < 0
+                                ? 0
+                                : 1),
+                          ),
+                        ),
+                      0,
+                    )
+                : undefined,
+              count: () => read(() => provider.getQueryLogCount(scoped), 0),
+              read: (offset: number, limit: number) =>
+                read(
+                  async () =>
+                    (
+                      await provider.getQueryLogRows({
+                        ...scoped,
+                        offset,
+                        limit,
+                      })
+                    ).map(source.identify),
+                  [],
+                ),
+            };
+          });
+        const items = await mergePage(
+          readers,
+          options,
+          (a, b) =>
+            new Date(b.requestTs ?? 0).getTime() -
+              new Date(a.requestTs ?? 0).getTime() ||
+            a.sourceId.localeCompare(b.sourceId),
+        );
+
+        if (failed.size === previousFailures) {
+          return { items, diagnostics: result.diagnostics };
+        }
+      }
+    },
+
+    async count(ids: string[], filters: QueryLogFilters) {
+      const result = await run(ids, (source, provider) => {
+        const options = {
+          ...source.scope,
+          search: filters.search,
+          client: filters.client,
+          questionType: filters.questionType,
+          responseType: filters.responseType,
+        };
+        return counts.get(JSON.stringify([source.id, options]), () =>
+          provider.getQueryLogCount(options),
+        );
+      });
+      return {
+        totalCount: result.values.reduce((sum, count) => sum + count, 0),
+        diagnostics: result.diagnostics,
+      };
+    },
+
+    async queriesOverTime(
+      ids: string[],
+      options: Parameters<LogProvider["getQueriesOverTime"]>[0],
+    ) {
+      const result = await run(ids, (source, provider) => {
+        const scoped = { ...options, ...source.scope };
+        return charts.get(JSON.stringify([source.id, scoped]), () =>
+          provider.getQueriesOverTime(scoped),
+        );
+      });
+      const buckets = new Map<
+        string,
+        { time: string; total: number; blocked: number; cached: number }
+      >();
+      for (const rows of result.values) {
+        for (const row of rows) {
+          const previous = buckets.get(row.time);
+          buckets.set(row.time, {
+            time: row.time,
+            total: row.total + (previous?.total ?? 0),
+            blocked: row.blocked + (previous?.blocked ?? 0),
+            cached: row.cached + (previous?.cached ?? 0),
+          });
+        }
+      }
+      return {
+        items: [...buckets.values()].sort((a, b) =>
+          a.time.localeCompare(b.time),
+        ),
+        diagnostics: result.diagnostics,
+      };
+    },
+
+    async topList(
+      ids: string[],
+      options: Parameters<typeof ranking>[1] & {
+        offset: number;
+        limit: number;
+      },
+    ) {
+      const result = await ranking(ids, options);
+
+      return {
+        items: await result.results.page(options.offset, options.limit),
+        totalCount: result.results.totalCount,
+        diagnostics: result.diagnostics,
+      };
+    },
+
+    async search(
+      ids: string[],
+      options: {
+        type: "domains" | "clients";
+        range: TimeRange;
+        query: string;
+        limit: number;
+      },
+    ) {
+      const result = await ranking(ids, {
+        type: options.type,
+        range: options.range,
+        filter: "all",
+      });
+      return {
+        items: await result.results.search(options.query, options.limit),
+        diagnostics: result.diagnostics,
+      };
+    },
+
+    async queryTypes(ids: string[], range: TimeRange) {
+      const result = await run(ids, async (source, provider) =>
+        (await provider.getQueryTypesBreakdown(range, source.scope)).map(
+          (item) => ({
+            name: item.type,
+            count: item.count,
+            blocked: 0,
+          }),
+        ),
+      );
+      return {
+        items: rank(result.values).map((item) => ({
+          type: item.name,
+          count: item.count,
+          percentage: item.percentage,
+        })),
+        diagnostics: result.diagnostics,
+      };
+    },
+  };
+}

--- a/src/server/logs/factory.test.ts
+++ b/src/server/logs/factory.test.ts
@@ -1,0 +1,62 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import Database from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { type Configuration } from "~/server/config/schema";
+import { type LogProvider } from "~/server/logs/types";
+
+const providers: LogProvider[] = [];
+let directory: string;
+
+beforeEach(async () => {
+  vi.resetModules();
+  vi.stubGlobal("blockyLogConnections", undefined);
+  directory = await mkdtemp(join(tmpdir(), "blocky-hmr-"));
+});
+
+afterEach(async () => {
+  await Promise.all(providers.splice(0).map((provider) => provider.close?.()));
+  vi.unstubAllGlobals();
+  await rm(directory, { recursive: true, force: true });
+});
+
+describe("database connections across module reloads", () => {
+  it.each(["mysql", "postgresql", "sqlite"] as const)(
+    "reloads %s provider code while retaining its connection",
+    async (type) => {
+      const sqlite = join(directory, "logs.sqlite");
+
+      if (type === "sqlite") {
+        new Database(sqlite).close();
+      }
+
+      const source: Configuration["logSources"][string] =
+        type === "sqlite"
+          ? { type, target: sqlite }
+          : { type, target: `${type}://test:test@127.0.0.1:1/blocky` };
+
+      const firstModule = await import("~/server/logs/factory");
+      const first = await firstModule.initializeLogSource(source);
+      providers.push(first);
+
+      const cacheKey = type === "postgresql" ? "postgres" : type;
+      const connection = globalThis.blockyLogConnections?.[cacheKey].get(
+        source.target,
+      );
+
+      vi.resetModules();
+
+      const reloadedModule = await import("~/server/logs/factory");
+      const reloaded = await reloadedModule.initializeLogSource(source);
+
+      expect(connection).toBeDefined();
+      expect(globalThis.blockyLogConnections?.[cacheKey].size).toBe(1);
+      expect(
+        globalThis.blockyLogConnections?.[cacheKey].get(source.target),
+      ).toBe(connection);
+      expect(reloaded.constructor).not.toBe(first.constructor);
+    },
+  );
+});

--- a/src/server/logs/factory.ts
+++ b/src/server/logs/factory.ts
@@ -1,0 +1,60 @@
+import { type createPool } from "mysql2/promise";
+import { type default as postgres } from "postgres";
+import { type default as Database } from "better-sqlite3";
+
+import { type Configuration } from "~/server/config/schema";
+import { type LogProvider } from "~/server/logs/types";
+import { MySQLLogProvider } from "~/server/logs/mysql/provider";
+import { PostgreSQLLogProvider } from "~/server/logs/postgres/provider";
+import { CsvLogProvider } from "~/server/logs/csv/provider";
+import { CsvClientLogProvider } from "~/server/logs/csv/client-provider";
+import { VictoriaLogsProvider } from "~/server/logs/victorialogs/provider";
+
+declare global {
+  var blockyLogConnections:
+    | {
+        mysql: Map<string, ReturnType<typeof createPool>>;
+        postgres: Map<string, ReturnType<typeof postgres>>;
+        sqlite: Map<string, Database.Database>;
+      }
+    | undefined;
+}
+
+export async function initializeLogSource(
+  source: Configuration["logSources"][string],
+): Promise<LogProvider> {
+  const connections = (globalThis.blockyLogConnections ??= {
+    mysql: new Map(),
+    postgres: new Map(),
+    sqlite: new Map(),
+  });
+
+  switch (source.type) {
+    case "mysql":
+      return new MySQLLogProvider({
+        connectionUri: source.target,
+        connections: connections.mysql,
+      });
+    case "postgresql":
+    case "timescale":
+      return new PostgreSQLLogProvider({
+        connectionUri: source.target,
+        connections: connections.postgres,
+      });
+    case "csv":
+      return new CsvLogProvider({ directory: source.target });
+    case "csv-client":
+      return new CsvClientLogProvider({ directory: source.target });
+    case "console":
+      return new VictoriaLogsProvider({ url: source.target });
+    case "sqlite": {
+      const { SQLiteLogProvider } =
+        await import("~/server/logs/sqlite/provider");
+
+      return new SQLiteLogProvider({
+        filePath: source.target,
+        connections: connections.sqlite,
+      });
+    }
+  }
+}

--- a/src/server/logs/index.test.ts
+++ b/src/server/logs/index.test.ts
@@ -59,3 +59,20 @@ describe("log coordinator lifetime", () => {
     expect(initializeLogSource).toHaveBeenCalledTimes(2);
   });
 });
+
+it("retries a legacy provider after initialization fails", async () => {
+  initializeLogSource.mockRejectedValueOnce(
+    new Error("Temporarily unavailable"),
+  );
+  const { createLogProvider } = await import("~/server/logs");
+
+  await expect(createLogProvider()).rejects.toThrow("Temporarily unavailable");
+  const [first, second] = await Promise.all([
+    createLogProvider(),
+    createLogProvider(),
+  ]);
+
+  expect(first).toBeDefined();
+  expect(second).toBe(first);
+  expect(initializeLogSource).toHaveBeenCalledTimes(2);
+});

--- a/src/server/logs/index.test.ts
+++ b/src/server/logs/index.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DemoLogProvider } from "~/server/logs/demo-provider";
+
+const { getConfiguration, initializeLogSource } = vi.hoisted(() => ({
+  getConfiguration: vi.fn(),
+  initializeLogSource: vi.fn(),
+}));
+
+vi.mock("~/env", () => ({ env: { DEMO_MODE: false } }));
+vi.mock("~/server/config", () => ({ getConfiguration }));
+vi.mock("~/server/logs/factory", () => ({ initializeLogSource }));
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+
+  getConfiguration.mockResolvedValue({
+    servers: {
+      main: { url: "http://blocky:4000", logs: { source: "history" } },
+    },
+    logSources: { history: { type: "csv", target: "/logs" } },
+  });
+  initializeLogSource.mockResolvedValue(new DemoLogProvider());
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("log coordinator lifetime", () => {
+  it("shares providers between concurrent requests without reloading", async () => {
+    const { getLogCoordinator } = await import("~/server/logs");
+    const [first, second] = await Promise.all([
+      getLogCoordinator(),
+      getLogCoordinator(),
+    ]);
+
+    await Promise.all([first.count(["main"], {}), second.count(["main"], {})]);
+
+    expect(first).toBe(second);
+    expect(getConfiguration).toHaveBeenCalledTimes(1);
+    expect(initializeLogSource).toHaveBeenCalledTimes(1);
+  });
+
+  it("replaces providers when their implementation is reloaded", async () => {
+    const firstModule = await import("~/server/logs");
+    const first = await firstModule.getLogCoordinator();
+
+    await first.count(["main"], {});
+    vi.resetModules();
+
+    const reloadedModule = await import("~/server/logs");
+    const reloaded = await reloadedModule.getLogCoordinator();
+
+    await reloaded.count(["main"], {});
+
+    expect(reloaded).not.toBe(first);
+    expect(getConfiguration).toHaveBeenCalledTimes(2);
+    expect(initializeLogSource).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/server/logs/index.ts
+++ b/src/server/logs/index.ts
@@ -20,21 +20,27 @@ export function getLogCoordinator() {
 let legacyProvider: Promise<LogProvider | undefined> | undefined;
 
 export function createLogProvider() {
-  legacyProvider ??= getConfiguration().then(async (configuration) => {
-    if (env.DEMO_MODE) {
-      return new DemoLogProvider();
-    }
+  legacyProvider ??= getConfiguration()
+    .then(async (configuration) => {
+      if (env.DEMO_MODE) {
+        return new DemoLogProvider();
+      }
 
-    const server = Object.values(configuration.servers)[0];
-    const source = server?.logs && configuration.logSources[server.logs.source];
+      const server = Object.values(configuration.servers)[0];
+      const source =
+        server?.logs && configuration.logSources[server.logs.source];
 
-    if (!source) {
-      return undefined;
-    }
+      if (!source) {
+        return undefined;
+      }
 
-    const { initializeLogSource } = await import("~/server/logs/factory");
-    return initializeLogSource(source);
-  });
+      const { initializeLogSource } = await import("~/server/logs/factory");
+      return initializeLogSource(source);
+    })
+    .catch((error: unknown) => {
+      legacyProvider = undefined;
+      throw error;
+    });
 
   return legacyProvider;
 }

--- a/src/server/logs/index.ts
+++ b/src/server/logs/index.ts
@@ -1,137 +1,40 @@
+import { type LogProvider } from "~/server/logs/types";
 import { env } from "~/env";
-import { MySQLLogProvider } from "~/server/logs/mysql/provider";
-import { PostgreSQLLogProvider } from "~/server/logs/postgres/provider";
+import { getConfiguration } from "~/server/config";
+import { createLogCoordinator } from "~/server/logs/coordinator";
 import { DemoLogProvider } from "~/server/logs/demo-provider";
-import { CsvLogProvider } from "~/server/logs/csv/provider";
-import { CsvClientLogProvider } from "~/server/logs/csv/client-provider";
-import { VictoriaLogsProvider } from "~/server/logs/victorialogs/provider";
-import type { LogProvider } from "~/server/logs/types";
 
-const globalForLogProvider = globalThis as unknown as {
-  logProvider: Promise<LogProvider | undefined> | undefined;
-};
+let coordinator: Promise<ReturnType<typeof createLogCoordinator>> | undefined;
 
-type SQLiteProviderModule = {
-  SQLiteLogProvider: new (options: { filePath: string }) => LogProvider;
-};
-
-/**
- * Cache provider initialization across HMR and concurrent requests.
- * This avoids duplicate file watchers and database connection pools.
- */
-export async function createLogProvider(): Promise<LogProvider | undefined> {
-  globalForLogProvider.logProvider ??= initializeLogProvider().catch(
-    (error) => {
-      globalForLogProvider.logProvider = undefined;
-      throw error;
-    },
+export function getLogCoordinator() {
+  coordinator ??= getConfiguration().then((configuration) =>
+    createLogCoordinator(
+      configuration,
+      env.DEMO_MODE ? async () => new DemoLogProvider() : undefined,
+    ),
   );
 
-  return globalForLogProvider.logProvider;
+  return coordinator;
 }
 
-async function initializeLogProvider(): Promise<LogProvider | undefined> {
-  if (env.DEMO_MODE) {
-    console.log("Using log provider type: demo");
-    return new DemoLogProvider();
-  }
+let legacyProvider: Promise<LogProvider | undefined> | undefined;
 
-  const logType = env.QUERY_LOG_TYPE?.toLowerCase();
-  const logTarget = env.QUERY_LOG_TARGET;
-
-  switch (logType) {
-    case "csv":
-      console.log("Using log provider type: csv, target:", logTarget);
-      return new CsvLogProvider({
-        directory: requireLogTarget(
-          logTarget,
-          "QUERY_LOG_TARGET must be set to a directory path when QUERY_LOG_TYPE == 'csv'",
-        ),
-      });
-
-    case "csv-client":
-      console.log("Using log provider type: csv-client, target:", logTarget);
-      return new CsvClientLogProvider({
-        directory: requireLogTarget(
-          logTarget,
-          "QUERY_LOG_TARGET must be set to a directory path when QUERY_LOG_TYPE == 'csv-client'",
-        ),
-      });
-
-    case "mysql":
-      console.log("Using log provider type: mysql");
-      return new MySQLLogProvider({
-        connectionUri: requireLogTarget(
-          logTarget,
-          "QUERY_LOG_TARGET (MySQL connection URI) is required when using QUERY_LOG_TYPE == 'mysql'",
-        ),
-      });
-
-    case "postgresql":
-    case "timescale":
-      console.log(`Using log provider type: ${logType}`);
-      return new PostgreSQLLogProvider({
-        connectionUri: requireLogTarget(
-          logTarget,
-          `QUERY_LOG_TARGET (PostgreSQL connection URI) is required when using QUERY_LOG_TYPE == '${logType}'`,
-        ),
-      });
-
-    case "sqlite":
-      console.log("Using log provider type: sqlite, target:", logTarget);
-      return createSQLiteLogProvider({
-        filePath: requireLogTarget(
-          logTarget,
-          "QUERY_LOG_TARGET (SQLite database file path) is required when using QUERY_LOG_TYPE == 'sqlite'",
-        ),
-      });
-
-    case "console": {
-      const consoleProvider = env.QUERY_LOG_CONSOLE_PROVIDER;
-      if (!consoleProvider) {
-        throw new Error(
-          "QUERY_LOG_CONSOLE_PROVIDER must be set when QUERY_LOG_TYPE == 'console' (supported values: 'victorialogs')",
-        );
-      }
-
-      console.log(
-        `Using log provider type: console (${consoleProvider}), target: ${logTarget}`,
-      );
-      return new VictoriaLogsProvider({
-        url: requireLogTarget(
-          logTarget,
-          "QUERY_LOG_TARGET (provider base URL) is required when using QUERY_LOG_TYPE == 'console'",
-        ),
-      });
+export function createLogProvider() {
+  legacyProvider ??= getConfiguration().then(async (configuration) => {
+    if (env.DEMO_MODE) {
+      return new DemoLogProvider();
     }
 
-    case undefined:
+    const server = Object.values(configuration.servers)[0];
+    const source = server?.logs && configuration.logSources[server.logs.source];
+
+    if (!source) {
       return undefined;
-  }
+    }
 
-  return undefined;
-}
+    const { initializeLogSource } = await import("~/server/logs/factory");
+    return initializeLogSource(source);
+  });
 
-async function createSQLiteLogProvider(options: {
-  filePath: string;
-}): Promise<LogProvider> {
-  let sqliteProviderModule: SQLiteProviderModule;
-
-  try {
-    sqliteProviderModule = await import("~/server/logs/sqlite/provider");
-  } catch (error) {
-    throw new Error("Failed to load the SQLite log provider.", {
-      cause: error,
-    });
-  }
-
-  return new sqliteProviderModule.SQLiteLogProvider(options);
-}
-
-function requireLogTarget(value: string | undefined, message: string): string {
-  if (!value) {
-    throw new Error(message);
-  }
-
-  return value;
+  return legacyProvider;
 }

--- a/src/server/logs/merge-page.test.ts
+++ b/src/server/logs/merge-page.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { mergePage } from "~/server/logs/merge-page";
+
+describe("paging sorted sources", () => {
+  it.each([false, true])(
+    "matches a complete merge with indexed boundaries %s",
+    async (indexed) => {
+      for (const size of [0, 1, 2, 3, 5, 10]) {
+        const groups = Array.from({ length: size }, (_, source) =>
+          Array.from(
+            { length: source % 3 === 0 ? 0 : 1500 + source * 113 },
+            (_, index) => ({
+              source,
+              index,
+              timestamp: Math.floor(index / 3) + source * 23,
+            }),
+          ),
+        );
+        const compare = (
+          a: { timestamp: number; source: number },
+          b: { timestamp: number; source: number },
+        ) => a.timestamp - b.timestamp || a.source - b.source;
+        const expected = groups.flat().sort(compare);
+        const sources = groups.map((items) => ({
+          count: async () => items.length,
+          countBefore: indexed
+            ? async (pivot: (typeof items)[number]) =>
+                items.filter((item) => compare(item, pivot) < 0).length
+            : undefined,
+          read: async (offset: number, limit: number) =>
+            items.slice(offset, offset + limit),
+        }));
+
+        for (const offset of [
+          0,
+          1,
+          256,
+          257,
+          800,
+          Math.floor(expected.length / 2),
+          expected.length - 1,
+          expected.length,
+          expected.length + 100,
+        ]) {
+          const start = Math.max(0, offset);
+          const page = await mergePage(
+            sources,
+            { offset: start, limit: 11 },
+            compare,
+          );
+
+          expect(page).toEqual(expected.slice(start, start + 11));
+        }
+      }
+    },
+  );
+});

--- a/src/server/logs/merge-page.ts
+++ b/src/server/logs/merge-page.ts
@@ -1,0 +1,129 @@
+import { mapConcurrent } from "~/server/utils/map-concurrent";
+
+export const MAX_PREFIX_ROWS = 256;
+
+export async function mergePage<T>(
+  sources: {
+    count(): Promise<number>;
+    read(offset: number, limit: number): Promise<T[]>;
+    countBefore?(pivot: T): Promise<number>;
+  }[],
+  options: { offset: number; limit: number },
+  compare: (a: T, b: T) => number,
+) {
+  if (sources.length === 1) {
+    return sources[0]?.read(options.offset, options.limit) ?? [];
+  }
+
+  let skip = options.offset;
+  const indexed = sources.every((source) => source.countBefore);
+  const states = await mapConcurrent(sources, 4, async (source) => ({
+    source,
+    offset: 0,
+    count: skip > MAX_PREFIX_ROWS && !indexed ? await source.count() : Infinity,
+  }));
+
+  function trimPrefix() {
+    const total = states.reduce(
+      (sum, state) => sum + Math.max(0, state.count - state.offset),
+      0,
+    );
+
+    if (skip >= total) {
+      return false;
+    }
+
+    const remaining = skip;
+
+    for (const state of states) {
+      const advance = Math.max(
+        0,
+        remaining - (total - Math.max(0, state.count - state.offset)),
+      );
+      state.offset += advance;
+      skip -= advance;
+    }
+
+    return true;
+  }
+
+  if (skip > MAX_PREFIX_ROWS && !indexed && !trimPrefix()) {
+    return [];
+  }
+
+  while (skip > Math.max(MAX_PREFIX_ROWS, sources.length)) {
+    const active = states.filter((state) => state.offset < state.count);
+
+    if (active.length === 0) {
+      return [];
+    }
+
+    if (active.length === 1) {
+      const state = active[0];
+
+      if (state) {
+        state.offset += skip;
+        skip = 0;
+      }
+
+      break;
+    }
+
+    const step = Math.floor(skip / active.length);
+    const candidates = await mapConcurrent(active, 4, async (state) => {
+      const advance = Math.min(Math.max(1, step), state.count - state.offset);
+      const [item] = await state.source.read(state.offset + advance - 1, 1);
+
+      return { state, advance, item };
+    });
+
+    if (candidates.some((candidate) => candidate.item === undefined)) {
+      await mapConcurrent(states, 4, async (state) => {
+        state.count = await state.source.count();
+      });
+
+      if (!trimPrefix()) {
+        return [];
+      }
+
+      continue;
+    }
+
+    const first = candidates
+      .flatMap(({ item, ...candidate }) =>
+        item === undefined ? [] : [{ ...candidate, item }],
+      )
+      .sort((a, b) => compare(a.item, b.item))[0];
+
+    if (first) {
+      first.state.offset += first.advance;
+      skip -= first.advance;
+
+      const advances = await mapConcurrent(candidates, 4, async (candidate) => {
+        const { state } = candidate;
+
+        if (state === first.state || !state.source.countBefore) {
+          return 0;
+        }
+
+        const rowsBeforePivot = await state.source.countBefore(first.item);
+        const unreadBeforePivot = Math.max(0, rowsBeforePivot - state.offset);
+        const advance = Math.min(candidate.advance, unreadBeforePivot);
+        state.offset += advance;
+
+        return advance;
+      });
+
+      skip -= advances.reduce((sum, advance) => sum + advance, 0);
+    }
+  }
+
+  const pages = await mapConcurrent(states, 4, (state) =>
+    state.source.read(state.offset, skip + options.limit),
+  );
+
+  return pages
+    .flat()
+    .sort(compare)
+    .slice(skip, skip + options.limit);
+}

--- a/src/server/logs/ranked-results.test.ts
+++ b/src/server/logs/ranked-results.test.ts
@@ -1,0 +1,26 @@
+import { expect, it } from "vitest";
+import { createRankedResults } from "~/server/logs/ranked-results";
+
+it("preserves ranking pages and search order across compressed blocks", async () => {
+  const items = Array.from({ length: 1300 }, (_, index) => ({
+    name:
+      index % 100 === 0 ? `café-${index}.example` : `domain-${index}.example`,
+    count: 1300 - index,
+    blocked: index % 3,
+    percentage: ((1300 - index) / 845650) * 100,
+  }));
+  const results = await createRankedResults(items);
+
+  expect(results.totalCount).toBe(items.length);
+
+  for (const offset of [0, 511, 512, 1020, 1299, 1300, 2000]) {
+    expect(await results.page(offset, 25)).toEqual(
+      items.slice(offset, offset + 25),
+    );
+  }
+
+  expect(await results.search("CAFÉ", 10)).toEqual(
+    items.filter((item) => item.name.startsWith("café")).slice(0, 10),
+  );
+  expect(await results.search("missing", 10)).toEqual([]);
+});

--- a/src/server/logs/ranked-results.ts
+++ b/src/server/logs/ranked-results.ts
@@ -1,0 +1,80 @@
+import { promisify } from "node:util";
+import { deflate, inflate } from "node:zlib";
+import { z } from "zod";
+import { mapConcurrent } from "~/server/utils/map-concurrent";
+
+const compress = promisify(deflate);
+const decompress = promisify(inflate);
+const BLOCK_SIZE = 512;
+const entrySchema = z.object({
+  name: z.string(),
+  count: z.number(),
+  blocked: z.number(),
+  percentage: z.number(),
+});
+const blockSchema = z.array(entrySchema);
+
+async function decode(block: Buffer) {
+  const json: unknown = JSON.parse((await decompress(block)).toString());
+
+  return blockSchema.parse(json);
+}
+
+export async function createRankedResults(
+  items: z.infer<typeof entrySchema>[],
+) {
+  const blocks = await mapConcurrent(
+    Array.from(
+      { length: Math.ceil(items.length / BLOCK_SIZE) },
+      (_, index) => index,
+    ),
+    4,
+    (index) =>
+      compress(
+        JSON.stringify(
+          items.slice(index * BLOCK_SIZE, (index + 1) * BLOCK_SIZE),
+        ),
+      ),
+  );
+
+  return rankedResults(blocks, items.length);
+}
+
+function rankedResults(blocks: Buffer[], totalCount: number) {
+  return {
+    totalCount,
+    bytes: blocks.reduce((sum, block) => sum + block.byteLength + 64, 0),
+
+    async page(offset: number, limit: number) {
+      const first = Math.floor(offset / BLOCK_SIZE);
+      const selected = blocks.slice(
+        first,
+        Math.ceil((offset + limit) / BLOCK_SIZE),
+      );
+      const pages = await mapConcurrent(selected, 4, decode);
+      const start = offset % BLOCK_SIZE;
+
+      return pages.flat().slice(start, start + limit);
+    },
+
+    async search(query: string, limit: number) {
+      const matches: z.infer<typeof entrySchema>[] = [];
+      const lower = query.toLowerCase();
+
+      for (const block of blocks) {
+        const items = await decode(block);
+        matches.push(
+          ...items
+            .filter((item) => item.name.toLowerCase().includes(lower))
+            .slice(0, limit - matches.length),
+        );
+
+        if (matches.length >= limit) {
+          break;
+        }
+      }
+
+      return matches;
+    },
+  };
+}

--- a/src/server/logs/result-cache.test.ts
+++ b/src/server/logs/result-cache.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from "vitest";
+import { createResultCache } from "~/server/logs/result-cache";
+
+describe("result cache", () => {
+  it("returns oversized results without retaining them", async () => {
+    const cache = createResultCache<number[]>({
+      ttlMs: 1000,
+      maxEntries: 10,
+      maxWeight: 3,
+      weightOf: (items) => items.length,
+    });
+    const oversized = vi.fn(async () => [1, 2, 3, 4]);
+    expect(await cache.get("large", oversized)).toEqual([1, 2, 3, 4]);
+    await cache.get("large", oversized);
+    expect(oversized).toHaveBeenCalledTimes(2);
+    const small = vi.fn(async () => [1]);
+    await cache.get("small", small);
+    await cache.get("small", small);
+    expect(small).toHaveBeenCalledTimes(1);
+  });
+  it("shares in-flight work and starts freshness when the slow query finishes", async () => {
+    let time = 0;
+    const cache = createResultCache<number>({
+      ttlMs: 30,
+      maxEntries: 2,
+      now: () => time,
+    });
+    let resolve: (value: number) => void = () => {};
+    const load = vi.fn(
+      () =>
+        new Promise<number>((done) => {
+          resolve = done;
+        }),
+    );
+    const first = cache.get("filter", load);
+    expect(cache.get("filter", load)).toBe(first);
+    await Promise.resolve();
+    time = 100;
+    resolve(5);
+    expect(await first).toBe(5);
+    time = 129;
+    expect(await cache.get("filter", load)).toBe(5);
+    expect(load).toHaveBeenCalledTimes(1);
+    time = 130;
+    expect(await cache.get("filter", async () => 6)).toBe(6);
+  });
+
+  it("evicts failed queries and the least recently used completed entry", async () => {
+    const cache = createResultCache<number>({ ttlMs: 1000, maxEntries: 2 });
+    await expect(
+      cache.get("failed", async () => {
+        throw new Error("offline");
+      }),
+    ).rejects.toThrow("offline");
+    expect(await cache.get("failed", async () => 1)).toBe(1);
+    await cache.get("second", async () => 2);
+    await cache.get("failed", async () => 9);
+    await cache.get("third", async () => 3);
+    expect(await cache.get("second", async () => 4)).toBe(4);
+  });
+});

--- a/src/server/logs/result-cache.ts
+++ b/src/server/logs/result-cache.ts
@@ -1,0 +1,75 @@
+export function createResultCache<T>({
+  ttlMs,
+  maxEntries,
+  maxWeight = Infinity,
+  weightOf = () => 1,
+  shouldCache = () => true,
+  now = Date.now,
+}: {
+  ttlMs: number;
+  maxEntries: number;
+  maxWeight?: number;
+  weightOf?: (value: T) => number;
+  shouldCache?: (value: T) => boolean;
+  now?: () => number;
+}) {
+  const entries = new Map<
+    string,
+    { value: Promise<T>; expiresAt: number; weight: number }
+  >();
+
+  function prune() {
+    let weight = [...entries.values()].reduce(
+      (total, entry) => total + entry.weight,
+      0,
+    );
+    for (const [key, entry] of entries) {
+      if (entries.size <= maxEntries && weight <= maxWeight) {
+        break;
+      }
+      weight -= entry.weight;
+      entries.delete(key);
+    }
+  }
+
+  return {
+    get(key: string, load: () => Promise<T>): Promise<T> {
+      const cached = entries.get(key);
+      if (cached && cached.expiresAt > now()) {
+        entries.delete(key);
+        entries.set(key, cached);
+        return cached.value;
+      }
+
+      const entry = {
+        value: Promise.resolve().then(load),
+        expiresAt: Infinity,
+        weight: 0,
+      };
+      entries.delete(key);
+      entries.set(key, entry);
+      prune();
+      void entry.value.then(
+        (value) => {
+          if (!shouldCache(value)) {
+            if (entries.get(key) === entry) {
+              entries.delete(key);
+            }
+
+            return;
+          }
+
+          entry.expiresAt = now() + ttlMs;
+          entry.weight = weightOf(value);
+          prune();
+        },
+        () => {
+          if (entries.get(key) === entry) {
+            entries.delete(key);
+          }
+        },
+      );
+      return entry.value;
+    },
+  };
+}

--- a/src/server/logs/sources.ts
+++ b/src/server/logs/sources.ts
@@ -1,0 +1,96 @@
+import { normalizeLogTimestamp } from "~/server/logs/timestamp";
+import { type Configuration } from "~/server/config/schema";
+import {
+  type LogEntry,
+  type LogProvider,
+  type LogScope,
+} from "~/server/logs/types";
+import { initializeLogSource } from "~/server/logs/factory";
+
+export function createLogSources(
+  configuration: Configuration,
+  initialize = initializeLogSource,
+) {
+  const providers = new Map<string, Promise<LogProvider>>();
+  const servers = Object.entries(configuration.servers);
+
+  function providerFor(id: string) {
+    const source = configuration.logSources[id];
+    if (!source) {
+      throw new Error("Unknown log source");
+    }
+    const existing = providers.get(id);
+    if (existing) {
+      return existing;
+    }
+    const pending = initialize(source);
+    providers.set(id, pending);
+    void pending.catch(() => {
+      if (providers.get(id) === pending) {
+        providers.delete(id);
+      }
+    });
+    return pending;
+  }
+
+  return {
+    select(serverIds: string[]) {
+      const selected = new Set(serverIds);
+      if (
+        !selected.size ||
+        serverIds.some((id) => !Object.hasOwn(configuration.servers, id))
+      ) {
+        throw new Error("Select configured servers before requesting logs.");
+      }
+      return Object.keys(configuration.logSources).flatMap((sourceId) => {
+        const owners = servers.filter(
+          ([, server]) => server.logs?.source === sourceId,
+        );
+        if (!owners.length) {
+          return [];
+        }
+        const soleOwner = owners.length === 1 ? owners[0] : undefined;
+        if (
+          soleOwner &&
+          !soleOwner[1].logs?.hostname &&
+          !selected.has(soleOwner[0])
+        ) {
+          return [];
+        }
+        const scope: LogScope = {
+          excludedHostnames: owners
+            .flatMap(([id, server]) =>
+              !selected.has(id) && server.logs?.hostname
+                ? [server.logs.hostname]
+                : [],
+            )
+            .sort(),
+        };
+        return [
+          {
+            id: sourceId,
+            scope,
+            provider: () => providerFor(sourceId),
+            identify(entry: LogEntry) {
+              const matched = owners.filter(
+                ([, server]) => server.logs?.hostname === entry.hostname,
+              );
+              const owner = matched.length === 1 ? matched[0] : undefined;
+              const dedicated =
+                owners.length === 1 && !owners[0]?.[1].logs?.hostname
+                  ? owners[0]
+                  : undefined;
+              const identified = owner ?? dedicated;
+              return {
+                ...entry,
+                requestTs: normalizeLogTimestamp(entry.requestTs),
+                sourceId,
+                serverId: identified?.[0] ?? null,
+              };
+            },
+          },
+        ];
+      });
+    },
+  };
+}


### PR DESCRIPTION
Adds a query-history coordinator that merges rows, charts, rankings and search suggestions across configured log sources. Shared sources are read once, and hostname mappings control which records can be attributed to a selected server.

Row lookahead and separately cached counts support pagination without recounting on every page. Provider failures remain identifiable, and database connections survive hot reloads.

Validated with coordinator tests, merged pagination against real providers, provider conformance and connection reuse tests. Static checks pass.

Part 4 of 7 in the multi-server stack. Review against `review/03-configured-server-api`.
