### PR TITLE
Add server targets and combined live statistics

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,11 @@
-import { Dashboard } from "~/components/dashboard/dashboard";
-import { env } from "~/env";
+import { ConnectedDashboard } from "~/components/dashboard/connected-dashboard";
+import { serverSummaries } from "~/server/config/servers";
+import { getConfiguration } from "~/server/config";
 
 export const dynamic = "force-dynamic";
 
-export default function HomePage() {
-  const showLogs = Boolean(env.QUERY_LOG_TARGET ?? env.DEMO_MODE);
+export default async function HomePage() {
+  const servers = serverSummaries(await getConfiguration());
 
   return (
     <main className="container mx-auto max-w-5xl px-4 py-8 sm:py-10">
@@ -14,7 +15,7 @@ export default function HomePage() {
         </h1>
       </header>
 
-      <Dashboard showLogs={showLogs} />
+      <ConnectedDashboard servers={servers} />
     </main>
   );
 }

--- a/src/components/dashboard/action-layout.tsx
+++ b/src/components/dashboard/action-layout.tsx
@@ -1,0 +1,19 @@
+import { type ReactNode } from "react";
+
+export function ActionLayout({
+  controls,
+  children,
+}: {
+  controls?: ReactNode;
+  children: ReactNode;
+}) {
+  if (!controls) {
+    return children;
+  }
+  return (
+    <div className="grid min-w-0 grid-cols-1 gap-5">
+      <div className="min-w-0">{controls}</div>
+      <div className="min-w-0">{children}</div>
+    </div>
+  );
+}

--- a/src/components/dashboard/connected-dashboard.tsx
+++ b/src/components/dashboard/connected-dashboard.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { Dashboard } from "~/components/dashboard/dashboard";
+import { ServerContext } from "~/components/dashboard/server-context";
+import { ActionTargets } from "~/components/dashboard/server-selector";
+import { useServerSelection } from "~/hooks/use-server-selection";
+import { api, type RouterOutputs } from "~/trpc/react";
+
+export function ConnectedDashboard({
+  servers: initialServers,
+}: {
+  servers: RouterOutputs["servers"]["list"];
+}) {
+  const { data: configuredServers } = api.servers.list.useQuery(undefined, {
+    initialData: initialServers,
+    refetchInterval: 30_000,
+  });
+  const servers = configuredServers;
+  const [logDiagnostics, setLogDiagnostics] = useState<
+    Record<string, { sourceId: string; message: string }[]>
+  >({});
+  const reportDiagnostics = useCallback(
+    (key: string, diagnostics: { sourceId: string; message: string }[]) => {
+      setLogDiagnostics((previous) =>
+        JSON.stringify(previous[key] ?? []) === JSON.stringify(diagnostics)
+          ? previous
+          : { ...previous, [key]: diagnostics },
+      );
+    },
+    [],
+  );
+  const ids = servers.map((server) => server.id);
+  const selection = useServerSelection(ids);
+  const status = api.servers.blockingStatus.useQuery(
+    { serverIds: ids },
+    { refetchInterval: 30_000 },
+  );
+  const statistics = api.servers.statistics.useQuery(
+    { serverIds: selection.selected("view") },
+    { refetchInterval: 30_000 },
+  );
+  const statuses = status.isError ? undefined : status.data;
+  const pickerServers = servers.map((server) => {
+    const result = statuses?.find((result) => result.serverId === server.id);
+    return {
+      id: server.id,
+      name: server.name,
+      online: result ? result.success : status.error ? false : undefined,
+      blocking: result?.success ? result.data.enabled : undefined,
+      disabledGroups: result?.success ? result.data.disabledGroups : undefined,
+      autoEnableInSec: result?.success
+        ? result.data.autoEnableInSec
+        : undefined,
+      statusUpdatedAt: status.dataUpdatedAt,
+    };
+  });
+  function controls(
+    scope: "blocking" | "maintenance" | "query",
+    label: string,
+  ) {
+    if (servers.length < 2) {
+      return undefined;
+    }
+    return (
+      <ActionTargets
+        actionLabel={scope === "query" ? "Run on" : "Apply to"}
+        matchTriggerWidth={scope !== "query"}
+        label={label}
+        selected={selection.selected(scope)}
+        servers={pickerServers}
+        onToggle={(id) => selection.toggle(scope, id)}
+      />
+    );
+  }
+  const unreachable = pickerServers.filter((server) => server.online === false);
+  const unavailableStatistics =
+    statistics.data
+      ?.filter(
+        (result) =>
+          !result.success &&
+          !unreachable.some((server) => server.id === result.serverId),
+      )
+      .map(
+        (result) =>
+          servers.find((server) => server.id === result.serverId)?.name ??
+          result.serverId,
+      ) ?? [];
+  const failedSources = [
+    ...new Set(
+      Object.values(logDiagnostics)
+        .flat()
+        .map((diagnostic) => diagnostic.sourceId),
+    ),
+  ];
+  const hasDiagnostics =
+    unreachable.length > 0 ||
+    unavailableStatistics.length > 0 ||
+    failedSources.length > 0 ||
+    Boolean(statistics.error);
+  return (
+    <ServerContext
+      value={{
+        servers,
+        selection,
+        statuses,
+        loading: status.isLoading,
+        statusUpdatedAt: status.dataUpdatedAt,
+        statistics: statistics.data,
+        statisticsLoading: statistics.isLoading,
+        reportDiagnostics,
+      }}
+    >
+      {hasDiagnostics && (
+        <div className="mb-6 space-y-3">
+          {hasDiagnostics && (
+            <div
+              role="status"
+              className="bg-card space-y-1 rounded-lg border px-4 py-3 text-sm"
+            >
+              {unreachable.length > 0 && (
+                <p className="text-amber-400">
+                  Unreachable:{" "}
+                  {unreachable.map((server) => server.name).join(", ")}
+                </p>
+              )}
+              {unavailableStatistics.length > 0 && (
+                <p className="text-amber-400">
+                  Statistics unavailable: {unavailableStatistics.join(", ")}
+                </p>
+              )}
+              {statistics.error && (
+                <p className="text-amber-400">
+                  Unable to load server statistics.
+                </p>
+              )}
+              {failedSources.length > 0 && (
+                <p className="text-amber-400">
+                  Log queries failed: {failedSources.join(", ")}
+                </p>
+              )}
+              <p className="text-muted-foreground text-xs">
+                Showing available data. Stored logs do not require a live server
+                connection.
+              </p>
+            </div>
+          )}
+        </div>
+      )}
+      <Dashboard
+        showLogs={servers.some((server) => server.hasLogs)}
+        blockingControls={controls("blocking", "Blocking targets")}
+        maintenanceControls={controls("maintenance", "Operation targets")}
+        queryControls={controls("query", "Query targets")}
+      />
+    </ServerContext>
+  );
+}

--- a/src/components/dashboard/dashboard.tsx
+++ b/src/components/dashboard/dashboard.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { type ReactNode } from "react";
+
 import { Operations } from "~/components/dashboard/operations";
 import { QueryLogs } from "~/components/dashboard/query-logs/query-logs";
 import { QueryTool } from "~/components/dashboard/query-tool";
@@ -9,19 +11,29 @@ import { StatisticsOverview } from "~/components/dashboard/statistics/statistics
 import { StatisticsTopLists } from "~/components/dashboard/statistics/statistics-top-lists";
 import { useDemoConfiguration } from "~/demo/context";
 
-export function Dashboard({ showLogs }: { showLogs: boolean }) {
+export function Dashboard({
+  showLogs,
+  blockingControls,
+  maintenanceControls,
+  queryControls,
+}: {
+  showLogs: boolean;
+  blockingControls?: ReactNode;
+  maintenanceControls?: ReactNode;
+  queryControls?: ReactNode;
+}) {
   const configuration = useDemoConfiguration();
   const showLogFeatures = showLogs && configuration.services.queryLogs;
 
   return (
     <div className="space-y-5 sm:space-y-6">
       <StatisticsOverview />
-      <div className="grid gap-6 md:grid-cols-2">
-        <ServerStatus />
-        <Operations />
+      <div className="grid gap-6 md:grid-cols-2 md:[&>[data-slot=card]]:row-span-2 md:[&>[data-slot=card]]:grid md:[&>[data-slot=card]]:grid-rows-subgrid">
+        <ServerStatus controls={blockingControls} />
+        <Operations controls={maintenanceControls} />
       </div>
       {showLogFeatures ? <ChartsSection /> : <StatisticsTopLists />}
-      <QueryTool />
+      <QueryTool controls={queryControls} />
       {showLogFeatures ? <QueryLogs /> : null}
     </div>
   );

--- a/src/components/dashboard/operations.tsx
+++ b/src/components/dashboard/operations.tsx
@@ -1,5 +1,10 @@
 "use client";
 
+import { useServerCommand } from "~/hooks/use-server-command";
+import { ActionLayout } from "~/components/dashboard/action-layout";
+
+import { type ReactNode } from "react";
+
 import { Activity, Shield, XCircle } from "lucide-react";
 import { Button } from "~/components/ui/button";
 import {
@@ -9,62 +14,45 @@ import {
   CardHeader,
   CardTitle,
 } from "~/components/ui/card";
-import { toast } from "sonner";
-import { api } from "~/trpc/react";
 
-export function Operations() {
-  const clearCacheMutation = api.blocky.cacheClear.useMutation({
-    onSuccess: () => {
-      toast.success("Cache has been cleared");
-    },
-    onError: (error) => {
-      toast.error("Failed to clear cache", {
-        description: error.message,
-      });
-    },
-  });
-
-  const refreshListsMutation = api.blocky.listsRefresh.useMutation({
-    onSuccess: () => {
-      toast.success("Lists have been refreshed");
-    },
-    onError: (error) => {
-      toast.error("Failed to refresh lists", {
-        description: error.message,
-      });
-    },
-  });
-
+export function Operations({ controls }: { controls?: ReactNode }) {
+  const command = useServerCommand("maintenance");
   return (
     <Card>
       <CardHeader>
-        <CardTitle className="flex items-center gap-2">
-          <Activity className="h-5 w-5" />
-          Operations
+        <CardTitle className="flex flex-wrap items-center justify-between gap-2">
+          <span className="flex items-center gap-2">
+            <Activity className="h-5 w-5" />
+            Operations
+          </span>
         </CardTitle>
         <CardDescription>
           Perform maintenance operations on the DNS server
         </CardDescription>
       </CardHeader>
-      <CardContent className="space-y-2">
-        <Button
-          variant="outline"
-          className="flex w-full items-center gap-2"
-          onClick={() => clearCacheMutation.mutate()}
-          disabled={clearCacheMutation.isPending}
-        >
-          <XCircle className="h-4 w-4" />
-          Clear DNS Cache
-        </Button>
-        <Button
-          variant="outline"
-          className="flex w-full items-center gap-2"
-          onClick={() => refreshListsMutation.mutate()}
-          disabled={refreshListsMutation.isPending}
-        >
-          <Shield className="h-4 w-4" />
-          Reload Allow/Denylists
-        </Button>
+      <CardContent>
+        <ActionLayout controls={controls}>
+          <div className="space-y-2">
+            <Button
+              variant="outline"
+              className="flex w-full items-center gap-2"
+              onClick={() => void command.execute({ action: "clearCache" })}
+              disabled={command.isPending}
+            >
+              <XCircle className="h-4 w-4" />
+              Clear DNS Cache
+            </Button>
+            <Button
+              variant="outline"
+              className="flex w-full items-center gap-2"
+              onClick={() => void command.execute({ action: "refreshLists" })}
+              disabled={command.isPending}
+            >
+              <Shield className="h-4 w-4" />
+              Reload Allow/Denylists
+            </Button>
+          </div>
+        </ActionLayout>
       </CardContent>
     </Card>
   );

--- a/src/components/dashboard/query-tool.tsx
+++ b/src/components/dashboard/query-tool.tsx
@@ -1,6 +1,9 @@
 "use client";
 
-import { Radio, Search } from "lucide-react";
+import { useServerQuery } from "~/hooks/use-server-query";
+import { ActionLayout } from "~/components/dashboard/action-layout";
+
+import { Radio, Search, Server } from "lucide-react";
 import { Button } from "~/components/ui/button";
 import {
   Card,
@@ -9,6 +12,7 @@ import {
   CardHeader,
   CardTitle,
 } from "~/components/ui/card";
+import { Skeleton } from "~/components/ui/skeleton";
 import { Input } from "~/components/ui/input";
 import {
   Select,
@@ -17,14 +21,52 @@ import {
   SelectTrigger,
   SelectValue,
 } from "~/components/ui/select";
-import { toast } from "sonner";
-import { api, type RouterOutputs } from "~/trpc/react";
-import { useState } from "react";
+import { type RouterOutputs } from "~/trpc/react";
+import { type ReactNode, useState } from "react";
 import { BLOCKY_DNS_RECORD_TYPES } from "~/lib/constants";
 import { cn } from "~/lib/utils";
 
 type DNS_RECORD_TYPE = (typeof BLOCKY_DNS_RECORD_TYPES)[number];
-type QueryResult = RouterOutputs["blocky"]["queryExecute"];
+type QueryResult = Extract<
+  RouterOutputs["servers"]["query"][number],
+  { success: true }
+>["data"];
+
+function QueryResultCard({
+  name,
+  children,
+}: {
+  name: string;
+  children: ReactNode;
+}) {
+  return (
+    <section
+      aria-label={`Query result for ${name}`}
+      className="bg-card overflow-hidden rounded-lg border"
+    >
+      <div className="flex items-center gap-2 border-b px-5 py-3 text-sm font-medium">
+        <Server className="text-muted-foreground size-4 shrink-0" />
+        <span className="min-w-0 break-words">{name}</span>
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function QueryResultColumns({
+  outcome,
+  answers,
+}: {
+  outcome: ReactNode;
+  answers: ReactNode;
+}) {
+  return (
+    <div className="grid sm:grid-cols-[minmax(0,1fr)_minmax(0,1.4fr)]">
+      {outcome}
+      {answers}
+    </div>
+  );
+}
 
 function QueryResultPane({
   responseType,
@@ -36,83 +78,78 @@ function QueryResultPane({
   const isBlocked = responseType === "BLOCKED";
 
   return (
-    <section
-      aria-live="polite"
-      className="mt-6 grid overflow-hidden rounded-md sm:grid-cols-[minmax(0,1fr)_minmax(0,1.4fr)]"
-    >
-      <div
-        className={cn(
-          "flex min-w-0 flex-col justify-between border-l-4 px-5 py-5",
-          isBlocked
-            ? "border-l-destructive bg-destructive/5"
-            : "border-l-primary bg-primary/5",
-        )}
-      >
-        <div className="flex items-center gap-2 text-xs tracking-widest uppercase">
-          <Radio className="h-3.5 w-3.5" /> Query outcome
-        </div>
-        <div className="mt-8 min-w-0">
-          <p className="text-3xl font-black tracking-tight break-all">
-            {responseType}
-          </p>
-          <p className="text-muted-foreground mt-1 font-mono text-xs">
-            {returnCode} / {answers.length} {answerLabel}
-          </p>
-          {detail && (
-            <p
-              className="text-muted-foreground mt-2 truncate text-xs"
-              title={detail}
-            >
-              {detail}
+    <QueryResultColumns
+      outcome={
+        <div
+          className={cn(
+            "flex min-w-0 flex-col justify-between border-l-4 px-5 py-5",
+            isBlocked
+              ? "border-l-destructive bg-destructive/5"
+              : "border-l-primary bg-primary/5",
+          )}
+        >
+          <div className="flex items-center gap-2 text-xs tracking-widest uppercase">
+            <Radio className="h-3.5 w-3.5" /> Query outcome
+          </div>
+          <div className="mt-8 min-w-0">
+            <p className="text-3xl font-black tracking-tight break-all">
+              {responseType}
             </p>
+            <p className="text-muted-foreground mt-1 font-mono text-xs">
+              {returnCode} / {answers.length} {answerLabel}
+            </p>
+            {detail && (
+              <p
+                className="text-muted-foreground mt-2 truncate text-xs"
+                title={detail}
+              >
+                {detail}
+              </p>
+            )}
+          </div>
+        </div>
+      }
+      answers={
+        <div className="flex max-h-64 min-h-0 min-w-0 flex-col gap-3 px-5 py-5 sm:border-l">
+          <p className="text-muted-foreground text-xs tracking-wide uppercase">
+            DNS answers
+          </p>
+          {answers.length === 0 ? (
+            <p className="text-muted-foreground text-sm">No answer returned</p>
+          ) : (
+            <div className="min-h-0 space-y-3 overflow-y-auto overscroll-contain pr-2">
+              {answers.map((answer, index) => (
+                <div
+                  key={`${answer}-${index}`}
+                  className="flex items-baseline gap-3"
+                >
+                  <span className="text-muted-foreground font-mono text-xs">
+                    {String(index + 1).padStart(2, "0")}
+                  </span>
+                  <span className="min-w-0 font-mono text-lg break-all select-text">
+                    {answer}
+                  </span>
+                </div>
+              ))}
+            </div>
           )}
         </div>
-      </div>
-      <div className="flex max-h-64 min-h-0 min-w-0 flex-col gap-3 px-5 py-5 sm:border-l">
-        <p className="text-muted-foreground text-xs tracking-wide uppercase">
-          DNS answers
-        </p>
-        {answers.length === 0 ? (
-          <p className="text-muted-foreground text-sm">No answer returned</p>
-        ) : (
-          <div className="min-h-0 space-y-3 overflow-y-auto overscroll-contain pr-2">
-            {answers.map((answer, index) => (
-              <div
-                key={`${answer}-${index}`}
-                className="flex items-baseline gap-3"
-              >
-                <span className="text-muted-foreground font-mono text-xs">
-                  {String(index + 1).padStart(2, "0")}
-                </span>
-                <span className="min-w-0 font-mono text-lg break-all select-text">
-                  {answer}
-                </span>
-              </div>
-            ))}
-          </div>
-        )}
-      </div>
-    </section>
+      }
+    />
   );
 }
 
-export function QueryTool() {
+export function QueryTool({ controls }: { controls?: ReactNode }) {
+  const serverQuery = useServerQuery();
   const [query, setQuery] = useState("");
   const [type, setType] = useState<DNS_RECORD_TYPE>(BLOCKY_DNS_RECORD_TYPES[0]);
 
-  const queryMutation = api.blocky.queryExecute.useMutation({
-    onError: (error) => {
-      toast.error("Query failed", {
-        description: error.message,
-      });
-    },
-  });
-
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    if (!query) return;
-
-    queryMutation.mutate({
+    if (!query) {
+      return;
+    }
+    serverQuery.execute({
       query,
       type,
     });
@@ -121,49 +158,108 @@ export function QueryTool() {
   return (
     <Card>
       <CardHeader>
-        <CardTitle className="flex items-center gap-2">
-          <Search className="h-5 w-5" />
-          Query Tool
+        <CardTitle className="flex flex-wrap items-center justify-between gap-2">
+          <span className="flex items-center gap-2">
+            <Search className="h-5 w-5" />
+            Query Tool
+          </span>
         </CardTitle>
         <CardDescription>Test DNS resolution for a domain</CardDescription>
       </CardHeader>
       <CardContent>
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div className="flex flex-col gap-2 sm:flex-row">
-            <Input
-              placeholder="Enter domain (e.g., example.com)"
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-              className="flex-1"
-            />
-            <Select
-              value={type}
-              onValueChange={(value: DNS_RECORD_TYPE) => setType(value)}
-            >
-              <SelectTrigger className="w-full sm:w-26">
-                <SelectValue placeholder="Type" />
-              </SelectTrigger>
-              <SelectContent>
-                {BLOCKY_DNS_RECORD_TYPES.map((recordType) => (
-                  <SelectItem key={recordType} value={recordType}>
-                    {recordType}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            <Button
-              type="submit"
-              variant="outline"
-              disabled={queryMutation.isPending}
-              className="flex items-center justify-center gap-2"
-            >
-              <Search className="h-4 w-4" />
-              Query
-            </Button>
-          </div>
-        </form>
+        <ActionLayout controls={controls}>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="flex flex-col gap-2 sm:flex-row">
+              <Input
+                placeholder="Enter domain (e.g., example.com)"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                className="flex-1"
+              />
+              <Select
+                value={type}
+                onValueChange={(value: DNS_RECORD_TYPE) => setType(value)}
+              >
+                <SelectTrigger className="w-full sm:w-26">
+                  <SelectValue placeholder="Type" />
+                </SelectTrigger>
+                <SelectContent>
+                  {BLOCKY_DNS_RECORD_TYPES.map((recordType) => (
+                    <SelectItem key={recordType} value={recordType}>
+                      {recordType}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <Button
+                type="submit"
+                variant="outline"
+                disabled={serverQuery.isPending}
+                className="flex items-center justify-center gap-2"
+              >
+                <Search className="h-4 w-4" />
+                Query
+              </Button>
+            </div>
+          </form>
 
-        {queryMutation.data && <QueryResultPane {...queryMutation.data} />}
+          {(serverQuery.results.length > 0 || serverQuery.isPending) && (
+            <div className="@container mt-5">
+              <div
+                role="region"
+                aria-label="DNS query results"
+                aria-live="polite"
+                aria-busy={serverQuery.isPending}
+                tabIndex={0}
+                className="-mr-5 max-h-[min(36rem,70vh)] overflow-y-auto overscroll-contain [color-scheme:dark]"
+              >
+                <div className="w-[100cqw] space-y-4">
+                  {serverQuery.results.length === 0 &&
+                    serverQuery.pendingServerIds.map((id) => (
+                      <QueryResultCard
+                        key={id}
+                        name={serverQuery.names[id] ?? id}
+                      >
+                        <QueryResultColumns
+                          outcome={
+                            <div className="border-muted space-y-8 border-l-4 px-5 py-5">
+                              <Skeleton className="h-4 w-28" />
+                              <div className="space-y-2">
+                                <Skeleton className="h-9 w-36" />
+                                <Skeleton className="h-4 w-24" />
+                              </div>
+                            </div>
+                          }
+                          answers={
+                            <div className="space-y-3 px-5 py-5 sm:border-l">
+                              <Skeleton className="h-4 w-24" />
+                              <Skeleton className="h-6 w-3/4" />
+                            </div>
+                          }
+                        />
+                      </QueryResultCard>
+                    ))}
+                  {serverQuery.results.map((result) => (
+                    <QueryResultCard
+                      key={result.serverId}
+                      name={
+                        serverQuery.names[result.serverId] ?? result.serverId
+                      }
+                    >
+                      {result.success ? (
+                        <QueryResultPane {...result.data} />
+                      ) : (
+                        <p className="text-destructive px-5 py-5 text-sm">
+                          {result.error.message}
+                        </p>
+                      )}
+                    </QueryResultCard>
+                  ))}
+                </div>
+              </div>
+            </div>
+          )}
+        </ActionLayout>
       </CardContent>
     </Card>
   );

--- a/src/components/dashboard/server-context.tsx
+++ b/src/components/dashboard/server-context.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { createContext, useContext } from "react";
+import { type RouterOutputs } from "~/trpc/react";
+import { type useServerSelection } from "~/hooks/use-server-selection";
+
+export type DashboardServers = {
+  servers: RouterOutputs["servers"]["list"];
+  selection: ReturnType<typeof useServerSelection>;
+  statuses: RouterOutputs["servers"]["blockingStatus"] | undefined;
+  loading: boolean;
+  statusUpdatedAt: number;
+  statistics: RouterOutputs["servers"]["statistics"] | undefined;
+  statisticsLoading: boolean;
+  reportDiagnostics: (
+    key: string,
+    diagnostics: { sourceId: string; message: string }[],
+  ) => void;
+};
+
+export const ServerContext = createContext<DashboardServers | null>(null);
+
+export function useDashboardServers() {
+  const context = useContext(ServerContext);
+  if (!context) {
+    throw new Error("Dashboard components require a server context.");
+  }
+  return context;
+}

--- a/src/components/dashboard/server-selector.tsx
+++ b/src/components/dashboard/server-selector.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+import { useCountdown } from "~/hooks/use-countdown";
+import { useState } from "react";
+import { ChevronDown, Search, Server as ServerIcon } from "lucide-react";
+import { Button } from "~/components/ui/button";
+import { Input } from "~/components/ui/input";
+import { Switch } from "~/components/ui/switch";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "~/components/ui/popover";
+import { cn } from "~/lib/utils";
+export type PickerServer = {
+  id: string;
+  name: string;
+  online: boolean | undefined;
+  blocking?: boolean;
+  disabledGroups?: string[];
+  autoEnableInSec?: number;
+  statusUpdatedAt?: number;
+};
+
+type SelectionProps = {
+  label: string;
+  selected: string[];
+  servers: PickerServer[];
+  onToggle: (id: string) => void;
+};
+
+function Health({ server }: { server: PickerServer }) {
+  return (
+    <span
+      className={cn(
+        "flex items-center gap-1.5 text-xs",
+        server.online === false ? "text-amber-400" : "text-muted-foreground",
+      )}
+    >
+      <span
+        className={cn(
+          "size-1.5 shrink-0 rounded-full",
+          server.online === undefined
+            ? "bg-muted-foreground"
+            : server.online
+              ? "bg-emerald-400"
+              : "bg-amber-400",
+        )}
+      />
+      {server.online === undefined
+        ? "Connecting"
+        : server.online
+          ? "Online"
+          : "Unreachable"}
+    </span>
+  );
+}
+
+function BlockingLabel({ server }: { server: PickerServer }) {
+  const remaining = useCountdown(
+    server.autoEnableInSec,
+    server.statusUpdatedAt ?? 0,
+  );
+  return (
+    <span
+      className={cn(
+        "max-w-32 rounded border px-1.5 py-0.5 text-[11px] break-words",
+        server.blocking
+          ? "border-emerald-400/30 text-emerald-400"
+          : "border-red-400/30 text-red-400",
+      )}
+      title={
+        [
+          server.disabledGroups?.length
+            ? `Disabled groups: ${server.disabledGroups.join(", ")}`
+            : undefined,
+          remaining ? `Blocking re-enables in ${remaining} seconds` : undefined,
+        ]
+          .filter(Boolean)
+          .join(". ") || undefined
+      }
+    >
+      {server.blocking
+        ? "Blocking on"
+        : remaining
+          ? `Off · ${Math.ceil(remaining / 60)}m`
+          : "Blocking off"}
+      {!server.blocking &&
+        Boolean(server.disabledGroups?.length) &&
+        ` · ${server.disabledGroups?.join(", ")}`}
+    </span>
+  );
+}
+
+function ServerList({ label, selected, servers, onToggle }: SelectionProps) {
+  const [search, setSearch] = useState("");
+  const matches = servers.filter((server) =>
+    `${server.name} ${server.id}`.toLowerCase().includes(search.toLowerCase()),
+  );
+  return (
+    <div className="min-w-0">
+      <div className="relative border-b p-2">
+        <Search className="text-muted-foreground pointer-events-none absolute top-5 left-4 size-4" />
+        <Input
+          aria-label={`Search ${label}`}
+          placeholder="Find a server"
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+          className="h-9 rounded-none border-0 bg-transparent pl-8 shadow-none focus-visible:ring-0 dark:bg-transparent"
+        />
+      </div>
+      <div
+        role="group"
+        aria-label={label}
+        className="max-h-56 overflow-y-auto overscroll-contain p-1 [color-scheme:dark]"
+      >
+        {matches.map((server) => {
+          const isSelected = selected.includes(server.id);
+          const isLastSelected = selected.length === 1 && isSelected;
+
+          return (
+            <label
+              key={server.id}
+              className="hover:bg-accent flex cursor-pointer items-center gap-3 rounded-md px-3 py-3"
+            >
+              <span className="min-w-0 flex-1">
+                <span className="block truncate text-sm">{server.name}</span>
+                <Health server={server} />
+              </span>
+              {label === "Blocking targets" && server.online && (
+                <BlockingLabel server={server} />
+              )}
+              <Switch
+                aria-label={`${label}: ${server.name}`}
+                checked={isSelected}
+                disabled={isLastSelected}
+                onCheckedChange={() => onToggle(server.id)}
+              />
+            </label>
+          );
+        })}
+        {!matches.length && (
+          <p className="text-muted-foreground px-3 py-5 text-sm">
+            No matching servers
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function ActionTargets({
+  actionLabel,
+  matchTriggerWidth = true,
+  ...props
+}: SelectionProps & { actionLabel: string; matchTriggerWidth?: boolean }) {
+  const selectedNames = props.servers
+    .filter((server) => props.selected.includes(server.id))
+    .map((server) => server.name);
+  const summary =
+    selectedNames.length === props.servers.length
+      ? `All ${props.servers.length} servers`
+      : `${selectedNames.length} ${selectedNames.length === 1 ? "server" : "servers"}`;
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          aria-label={`Choose ${props.label}`}
+          className="bg-card dark:bg-card dark:hover:bg-accent h-auto w-full justify-start gap-3 rounded-lg p-3"
+        >
+          <ServerIcon className="text-muted-foreground size-5 shrink-0" />
+          <span className="min-w-0 flex-1 text-left">
+            <span className="block text-sm font-medium">
+              <span className="text-muted-foreground font-normal">
+                {actionLabel}:{" "}
+              </span>
+              {summary}
+            </span>
+            <span className="text-muted-foreground block truncate text-xs font-normal">
+              {selectedNames.join(", ")}
+            </span>
+          </span>
+          {props.servers.some(
+            (server) =>
+              props.selected.includes(server.id) && server.online === false,
+          ) && (
+            <span className="text-xs text-amber-400">
+              {
+                props.servers.filter(
+                  (server) =>
+                    props.selected.includes(server.id) &&
+                    server.online === false,
+                ).length
+              }{" "}
+              unreachable
+            </span>
+          )}
+          <ChevronDown className="text-muted-foreground size-4" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        className={cn(
+          "bg-popover dark:bg-popover max-w-[calc(100vw-2rem)] overflow-hidden p-0",
+          matchTriggerWidth ? "w-[var(--radix-popover-trigger-width)]" : "w-80",
+        )}
+      >
+        <ServerList {...props} />
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/components/dashboard/server-status.tsx
+++ b/src/components/dashboard/server-status.tsx
@@ -1,6 +1,11 @@
 "use client";
 
-import { Database, Loader2, Power, AlertCircle, Pause } from "lucide-react";
+import { type ReactNode, useEffect } from "react";
+import { Database, Power, Pause } from "lucide-react";
+import { ActionLayout } from "~/components/dashboard/action-layout";
+import { useDashboardServers } from "~/components/dashboard/server-context";
+import { useServerCommand } from "~/hooks/use-server-command";
+import { useCountdown } from "~/hooks/use-countdown";
 import { Button } from "~/components/ui/button";
 import {
   Card,
@@ -9,10 +14,9 @@ import {
   CardHeader,
   CardTitle,
 } from "~/components/ui/card";
+import { Skeleton } from "~/components/ui/skeleton";
 import { Badge } from "~/components/ui/badge";
-import { toast } from "sonner";
 import { api } from "~/trpc/react";
-import { startTransition, useEffect, useState } from "react";
 import { cn } from "~/lib/utils";
 
 const DURATION_PRESETS = [
@@ -22,171 +26,124 @@ const DURATION_PRESETS = [
   { label: "Disable", value: "0", icon: Power },
 ];
 
-export function ServerStatus() {
+export function ServerStatus({ controls }: { controls?: ReactNode }) {
+  const dashboard = useDashboardServers();
+  const command = useServerCommand("blocking");
   const utils = api.useUtils();
-  const {
-    data: status,
-    isLoading,
-    isFetching,
-    error,
-  } = api.blocky.blockingStatus.useQuery();
-  const [countdown, setCountdown] = useState<number | null>(null);
-
+  const targets = dashboard.selection.selected("blocking");
+  const known =
+    dashboard.statuses?.flatMap((result) =>
+      targets.includes(result.serverId) && result.success ? [result.data] : [],
+    ) ?? [];
+  const enabled = known.filter((status) => status.enabled).length;
+  const disabled = known.length - enabled;
+  const unavailable = targets.length - known.length;
+  const mixed = enabled > 0 && disabled > 0;
+  const countdown = useCountdown(
+    targets.length === 1 ? known[0]?.autoEnableInSec : undefined,
+    dashboard.statusUpdatedAt,
+  );
   useEffect(() => {
-    startTransition(() => {
-      setCountdown(status?.autoEnableInSec ?? null);
-    });
-  }, [status?.autoEnableInSec]);
-
-  const enableMutation = api.blocky.blockingEnable.useMutation({
-    onSuccess: () => {
-      toast.success("Blocking has been enabled");
-      void utils.blocky.blockingStatus.invalidate();
-    },
-    onError: (error) => {
-      toast.error("Failed to enable blocking", {
-        description: error.message,
-      });
-    },
-  });
-
-  const disableMutation = api.blocky.blockingDisable.useMutation({
-    onSuccess: () => {
-      toast.success("Blocking has been disabled");
-      void utils.blocky.blockingStatus.invalidate();
-    },
-    onError: (error) => {
-      toast.error("Failed to disable blocking", {
-        description: error.message,
-      });
-    },
-  });
-
-  useEffect(() => {
-    if (countdown === null) return undefined;
-
-    const timer = setInterval(() => {
-      setCountdown((prev) => {
-        if (prev === null || prev <= 0) {
-          clearInterval(timer);
-          return null;
-        }
-        return prev - 1;
-      });
-    }, 1000);
-
-    return () => clearInterval(timer);
-  }, [countdown]);
-
-  useEffect(() => {
-    if (error) {
-      toast.error("Failed to query blocking status", {
-        description: error.message,
-      });
+    if (countdown === 0) {
+      void utils.servers.blockingStatus.invalidate();
     }
-  }, [error]);
+  }, [countdown, utils]);
 
-  const formatTime = (seconds: number) => {
-    const minutes = Math.floor(seconds / 60);
-    const remainingSeconds = seconds % 60;
-    return `${minutes}m ${remainingSeconds.toString().padStart(2, "0")}s`;
-  };
-
-  let description = "";
-
-  if (error) {
-    description = "";
-  } else if (status?.enabled) {
-    description = "Blocking is currently enabled.";
-  } else if (countdown) {
-    description = `Blocking is temporarily disabled. Auto-enables in ${formatTime(countdown)}.`;
-  } else if (!isLoading) {
-    description = "Blocking is disabled until manually enabled.";
-  }
-
-  let content = null;
-
-  if (error) {
-    content = (
-      <div className="flex h-full flex-col items-center justify-center gap-2 text-center text-red-400">
-        <AlertCircle className="h-8 w-8" />
-        <p className="text-sm">{error.message}</p>
-      </div>
-    );
-  } else if (status?.enabled) {
-    content = (
-      <div className="space-y-4">
-        <div>
-          <div className="grid grid-cols-2 gap-2">
-            {DURATION_PRESETS.map((preset) => {
-              const Icon = preset.icon;
-              return (
-                <Button
-                  key={preset.value}
-                  variant={preset.value === "0" ? "destructive" : "outline"}
-                  onClick={() =>
-                    disableMutation.mutate({ duration: preset.value })
-                  }
-                  disabled={isFetching || disableMutation.isPending}
-                  className="flex items-center gap-2"
-                >
-                  <Icon className="h-4 w-4" />
-                  {preset.label}
-                </Button>
-              );
-            })}
-          </div>
-        </div>
-      </div>
-    );
-  } else if (!isLoading) {
-    content = (
-      <Button
-        className="flex w-full items-center gap-2"
-        onClick={() => enableMutation.mutate()}
-        disabled={isFetching || enableMutation.isPending}
-      >
-        <Power className="h-4 w-4" />
-        Enable
-      </Button>
-    );
-  } else {
-    content = (
-      <div className="flex justify-center">
-        <Loader2 className="h-10 w-10 animate-spin" />
-      </div>
-    );
-  }
+  const showDisable = enabled > 0 || unavailable > 0;
 
   return (
     <Card className="min-h-52">
       <CardHeader>
-        <CardTitle className="flex items-center justify-between">
+        <CardTitle className="flex flex-wrap items-center justify-between gap-2">
           <span className="flex items-center gap-2">
             <Database className="h-5 w-5" />
             Blocking Status
           </span>
-          <Badge
-            variant="outline"
-            className={cn(
-              (isLoading || error) && "invisible",
-              status?.enabled
-                ? "border-green-400 bg-green-400/10 text-green-600"
-                : "border-red-400 bg-red-400/10 text-red-400",
-            )}
-          >
-            {status?.enabled ? "Enabled" : "Disabled"}
-          </Badge>
+          {dashboard.loading ? (
+            <Skeleton className="h-5 w-16" />
+          ) : (
+            <Badge
+              variant="outline"
+              className={cn(
+                mixed || unavailable > 0
+                  ? "border-amber-400 bg-amber-400/10 text-amber-400"
+                  : enabled > 0
+                    ? "border-green-400 bg-green-400/10 text-green-600"
+                    : "border-red-400 bg-red-400/10 text-red-400",
+              )}
+            >
+              {mixed
+                ? "Mixed"
+                : unavailable > 0
+                  ? "Unknown"
+                  : enabled > 0
+                    ? "Enabled"
+                    : "Disabled"}
+            </Badge>
+          )}
         </CardTitle>
-        <CardDescription>{description}</CardDescription>
+        <CardDescription>
+          Enable blocking or pause it temporarily
+        </CardDescription>
       </CardHeader>
-      <CardContent
-        className={cn(
-          "flex flex-1 flex-col",
-          (isLoading || error) && "justify-center",
-        )}
-      >
-        {content}
+      <CardContent>
+        <ActionLayout controls={controls}>
+          {dashboard.loading ? (
+            <div
+              className="grid grid-cols-2 gap-2"
+              aria-label="Loading blocking status"
+            >
+              {DURATION_PRESETS.map((preset) => (
+                <Skeleton key={preset.value} className="h-9 w-full" />
+              ))}
+            </div>
+          ) : (
+            <div className="space-y-4">
+              {disabled > 0 && countdown !== null && countdown > 0 && (
+                <p className="text-muted-foreground text-sm tabular-nums">
+                  Auto-enables in {Math.floor(countdown / 60)}m{" "}
+                  {(countdown % 60).toString().padStart(2, "0")}s
+                </p>
+              )}
+              {(disabled > 0 || unavailable > 0) && (
+                <Button
+                  className="flex w-full items-center gap-2"
+                  disabled={command.isPending}
+                  onClick={() => void command.execute({ action: "enable" })}
+                >
+                  {!showDisable && <Power className="size-4" />}
+                  {targets.length > 1 ? "Enable on selected servers" : "Enable"}
+                </Button>
+              )}
+              {showDisable && (
+                <div className="grid grid-cols-2 gap-2">
+                  {DURATION_PRESETS.map((preset) => {
+                    const Icon = preset.icon;
+                    return (
+                      <Button
+                        key={preset.value}
+                        variant={
+                          preset.value === "0" ? "destructive" : "outline"
+                        }
+                        disabled={command.isPending}
+                        className="flex items-center gap-2"
+                        onClick={() =>
+                          void command.execute({
+                            action: "disable",
+                            duration: preset.value,
+                          })
+                        }
+                      >
+                        <Icon className="size-4" />
+                        {preset.label}
+                      </Button>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          )}
+        </ActionLayout>
       </CardContent>
     </Card>
   );

--- a/src/components/dashboard/statistics/stat-card.tsx
+++ b/src/components/dashboard/statistics/stat-card.tsx
@@ -1,3 +1,4 @@
+import { type ReactNode } from "react";
 import { type LucideIcon } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
 import { Badge } from "~/components/ui/badge";
@@ -11,7 +12,8 @@ import { formatCount } from "~/lib/utils";
 
 interface StatCardProps {
   title: string;
-  value: string | number;
+  value?: string | number;
+  children?: ReactNode;
   valueLabel?: string;
   icon: LucideIcon;
   badge?: {
@@ -32,7 +34,8 @@ function formatValue(value: string | number): string {
 
 export function StatCard({
   title,
-  value,
+  value = 0,
+  children,
   valueLabel,
   icon: Icon,
   badge,
@@ -47,9 +50,11 @@ export function StatCard({
           <Skeleton className="h-4 w-24" />
           <Skeleton className="h-5 w-5 rounded" />
         </CardHeader>
-        <CardContent>
-          <Skeleton className="mb-2 h-8 w-20" />
-          {detail !== undefined && <Skeleton className="h-2 w-full" />}
+        <CardContent className="min-h-15">
+          <Skeleton className="mb-2 h-9 w-20" />
+          {(children || detail !== undefined) && (
+            <Skeleton className="h-4 w-full" />
+          )}
         </CardContent>
       </Card>
     );
@@ -74,22 +79,28 @@ export function StatCard({
         )}
         <Icon className="text-muted-foreground h-5 w-5" />
       </CardHeader>
-      <CardContent>
-        <div className="mb-2 flex items-baseline gap-2">
-          <span className="text-3xl font-bold">{formatValue(value)}</span>
-          {valueLabel && (
-            <span className="text-foreground text-sm font-medium">
-              {valueLabel}
-            </span>
-          )}
-          {badge && (
-            <Badge variant={badge.variant ?? "secondary"}>{badge.value}</Badge>
-          )}
-        </div>
-        {detail && (
-          <p className="text-muted-foreground mt-2 text-xs tabular-nums">
-            {detail}
-          </p>
+      <CardContent className="min-h-15">
+        {children ?? (
+          <>
+            <div className="mb-2 flex items-baseline gap-2">
+              <span className="text-3xl font-bold">{formatValue(value)}</span>
+              {valueLabel && (
+                <span className="text-foreground text-sm font-medium">
+                  {valueLabel}
+                </span>
+              )}
+              {badge && (
+                <Badge variant={badge.variant ?? "secondary"}>
+                  {badge.value}
+                </Badge>
+              )}
+            </div>
+            {detail && (
+              <p className="text-muted-foreground mt-2 text-xs tabular-nums">
+                {detail}
+              </p>
+            )}
+          </>
         )}
       </CardContent>
     </Card>

--- a/src/components/dashboard/statistics/statistics-overview.tsx
+++ b/src/components/dashboard/statistics/statistics-overview.tsx
@@ -1,13 +1,52 @@
 "use client";
 
-import { Activity, ChartPie, Database, List } from "lucide-react";
+import { aggregateStatistics } from "~/lib/aggregate-statistics";
+import { useDashboardServers } from "~/components/dashboard/server-context";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "~/components/ui/popover";
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableHead,
+  TableCell,
+} from "~/components/ui/table";
+import { Button } from "~/components/ui/button";
+import { Activity, ChartPie, Database, List, ChevronDown } from "lucide-react";
 import { formatCount } from "~/lib/utils";
-import { api } from "~/trpc/react";
 import { StatCard } from "./stat-card";
 
 export function StatisticsOverview() {
-  const { data: snapshot, isLoading } = api.stats.snapshot.useQuery();
-  const overview = snapshot?.overview;
+  const dashboard = useDashboardServers();
+  const overview = aggregateStatistics(dashboard.statistics ?? []);
+  const isLoading = dashboard.statisticsLoading;
+  const inventories =
+    dashboard.statistics?.flatMap((result) =>
+      result.success
+        ? [
+            {
+              id: result.serverId,
+              name:
+                dashboard.servers.find(
+                  (server) => server.id === result.serverId,
+                )?.name ?? result.serverId,
+              ...result.data.overview,
+            },
+          ]
+        : [],
+    ) ?? [];
+  const inventory = inventories[0];
+  const domainCounts = inventories.map((server) => server.listedDomains);
+  const minimum = domainCounts.length ? Math.min(...domainCounts) : 0;
+  const maximum = domainCounts.length ? Math.max(...domainCounts) : 0;
+  const domainRange =
+    minimum === maximum
+      ? formatCount(minimum)
+      : `${formatCount(minimum)} to ${formatCount(maximum)}`;
 
   if (!isLoading && !overview) {
     return null;
@@ -60,18 +99,85 @@ export function StatisticsOverview() {
             : "0 cached entries"
         }
       />
-      <StatCard
-        title="Listed Domains"
-        value={overview?.listedDomains ?? 0}
-        icon={List}
-        isLoading={isLoading}
-        tooltip="Total domains in blocklists"
-        detail={
-          overview
-            ? `${overview.denylistGroups} deny groups · ${formatCount(overview.allowlistDomains)} allowlisted`
-            : "0 deny groups · 0 allowlisted"
-        }
-      />
+      {dashboard.selection.selected("view").length > 1 ? (
+        <StatCard title="Listed Domains" icon={List} isLoading={isLoading}>
+          <Popover>
+            <PopoverTrigger asChild>
+              <Button
+                variant="ghost"
+                aria-label="View listed domains by server"
+                className="hover:bg-accent -mx-2 -my-1 h-17 w-[calc(100%+1rem)] flex-col items-start gap-2 px-2 py-1 text-left"
+              >
+                <span className="flex w-full items-center justify-between gap-2">
+                  <span className="text-xl font-bold tabular-nums">
+                    {domainRange}
+                  </span>
+                  <ChevronDown className="text-muted-foreground size-4 shrink-0" />
+                </span>
+                <span className="text-muted-foreground text-xs font-normal">
+                  {minimum === maximum ? "Per server" : "Range per server"}
+                </span>
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent
+              align="end"
+              collisionPadding={16}
+              className="bg-popover dark:bg-popover w-132 max-w-[calc(100vw-2rem)] p-0"
+              aria-label="Listed domains by server"
+            >
+              <div className="max-h-[min(32rem,60vh,var(--radix-popover-content-available-height))] [scrollbar-gutter:stable] overflow-y-auto overscroll-contain rounded-md [color-scheme:dark] [&>[data-slot=table-container]]:overflow-visible">
+                <Table className="table-fixed text-xs sm:text-sm">
+                  <TableHeader className="bg-popover sticky top-0 z-10">
+                    <TableRow className="hover:bg-transparent [&>th]:h-auto [&>th]:py-3 [&>th]:leading-5">
+                      <TableHead className="w-[30%] pl-4">Server</TableHead>
+                      <TableHead className="w-[22%] text-right">
+                        Domains
+                      </TableHead>
+                      <TableHead className="w-[24%] text-right">
+                        Allowlisted
+                      </TableHead>
+                      <TableHead className="w-[24%] pr-4 text-right whitespace-normal">
+                        Deny groups
+                      </TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {inventories.map((server) => (
+                      <TableRow key={server.id}>
+                        <TableCell className="py-3 pl-4 font-medium break-words whitespace-normal">
+                          {server.name}
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums">
+                          {server.listedDomains.toLocaleString()}
+                        </TableCell>
+                        <TableCell className="text-muted-foreground text-right tabular-nums">
+                          {server.allowlistDomains.toLocaleString()}
+                        </TableCell>
+                        <TableCell className="text-muted-foreground pr-4 text-right tabular-nums">
+                          {server.denylistGroups}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            </PopoverContent>
+          </Popover>
+        </StatCard>
+      ) : (
+        <StatCard
+          title="Listed Domains"
+          value={inventory?.listedDomains ?? 0}
+          icon={List}
+          isLoading={isLoading}
+          tooltip="Total domains in blocklists"
+          detail={
+            inventory
+              ? `${inventory.denylistGroups} deny groups · ${formatCount(inventory.allowlistDomains)} allowlisted`
+              : "0 deny groups · 0 allowlisted"
+          }
+        />
+      )}
     </div>
   );
 }

--- a/src/components/dashboard/statistics/statistics-top-lists.tsx
+++ b/src/components/dashboard/statistics/statistics-top-lists.tsx
@@ -3,7 +3,14 @@
 import { useState } from "react";
 import { Globe, ListOrdered, Users, type LucideIcon } from "lucide-react";
 
-import { api } from "~/trpc/react";
+import { useDashboardServers } from "~/components/dashboard/server-context";
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from "~/components/ui/select";
 import {
   TopListCard,
   TopListEntry,
@@ -83,7 +90,16 @@ function StatisticsTopList({
 
 export function StatisticsTopLists() {
   const [domainFilter, setDomainFilter] = useState<TopListFilter>("all");
-  const { data: snapshot, isLoading } = api.stats.snapshot.useQuery();
+  const dashboard = useDashboardServers();
+  const [serverId, setServerId] = useState<string>();
+  const available =
+    dashboard.statistics?.flatMap((result) =>
+      result.success ? [{ serverId: result.serverId, data: result.data }] : [],
+    ) ?? [];
+  const current =
+    available.find((result) => result.serverId === serverId) ?? available[0];
+  const snapshot = current?.data;
+  const isLoading = dashboard.statisticsLoading;
 
   if (!isLoading && !snapshot) {
     return null;
@@ -101,6 +117,27 @@ export function StatisticsTopLists() {
     <TopListsSection
       description="Most active domains and clients in the last 24 hours"
       icon={ListOrdered}
+      controls={
+        available.length > 1 ? (
+          <Select value={current?.serverId} onValueChange={setServerId}>
+            <SelectTrigger
+              aria-label="Top lists server"
+              className="w-full sm:w-48"
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {available.map((result) => (
+                <SelectItem key={result.serverId} value={result.serverId}>
+                  {dashboard.servers.find(
+                    (server) => server.id === result.serverId,
+                  )?.name ?? result.serverId}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        ) : undefined
+      }
     >
       <StatisticsTopList
         title="Top Domains"

--- a/src/hooks/use-countdown.ts
+++ b/src/hooks/use-countdown.ts
@@ -1,0 +1,21 @@
+"use client";
+
+import { startTransition, useEffect, useState } from "react";
+
+export function useCountdown(seconds: number | undefined, updatedAt: number) {
+  const [remaining, setRemaining] = useState<number | null>(null);
+  useEffect(() => {
+    if (!seconds) {
+      startTransition(() => setRemaining(null));
+      return;
+    }
+    const deadline = updatedAt + seconds * 1000;
+    function tick() {
+      setRemaining(Math.max(0, Math.ceil((deadline - Date.now()) / 1000)));
+    }
+    startTransition(tick);
+    const timer = setInterval(tick, 1000);
+    return () => clearInterval(timer);
+  }, [seconds, updatedAt]);
+  return remaining;
+}

--- a/src/hooks/use-server-command.test.ts
+++ b/src/hooks/use-server-command.test.ts
@@ -1,0 +1,83 @@
+import { QueryClient } from "@tanstack/react-query";
+import { expect, it, vi } from "vitest";
+import { useServerCommand } from "~/hooks/use-server-command";
+
+const mocks = vi.hoisted(() => ({
+  useUtils: vi.fn(),
+  mutateAsync: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock("~/trpc/react", () => ({
+  api: {
+    useUtils: mocks.useUtils,
+    servers: {
+      command: {
+        useMutation: () => ({ mutateAsync: mocks.mutateAsync }),
+      },
+    },
+  },
+}));
+
+vi.mock("~/components/dashboard/server-context", () => ({
+  useDashboardServers: () => ({
+    servers: [{ id: "home", name: "Home" }],
+    selection: { selected: () => ["home"] },
+  }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: mocks.error },
+}));
+
+it("checks current blocking state before retrying despite a fresh cached status", async () => {
+  const client = new QueryClient({
+    defaultOptions: { queries: { staleTime: 30_000 } },
+  });
+  const queryKey = ["blockingStatus", "home"];
+  const currentStatus = vi.fn(async () => [
+    { serverId: "home", success: true, data: { enabled: false } },
+  ]);
+  let retry: (() => void) | undefined;
+
+  mocks.error.mockImplementation(
+    (_message: string, options: { action?: { onClick: () => void } }) => {
+      retry = options.action?.onClick;
+    },
+  );
+  mocks.useUtils.mockReturnValue({
+    servers: {
+      blockingStatus: {
+        invalidate: vi.fn(),
+        fetch: (_input: unknown, options?: { staleTime?: number }) =>
+          client.fetchQuery({ queryKey, queryFn: currentStatus, ...options }),
+      },
+      statistics: { invalidate: vi.fn() },
+    },
+  });
+  mocks.mutateAsync
+    .mockResolvedValueOnce([
+      { serverId: "home", success: false, error: { kind: "timeout" } },
+    ])
+    .mockResolvedValueOnce([{ serverId: "home", success: true }]);
+
+  const command = useServerCommand("blocking");
+
+  await command.execute({ action: "enable" });
+
+  client.setQueryData(queryKey, [
+    { serverId: "home", success: true, data: { enabled: true } },
+  ]);
+
+  expect(retry).toBeDefined();
+  retry?.();
+
+  await vi.waitFor(() => expect(mocks.mutateAsync).toHaveBeenCalledTimes(2));
+  expect(currentStatus).toHaveBeenCalledOnce();
+  expect(mocks.mutateAsync).toHaveBeenLastCalledWith({
+    serverIds: ["home"],
+    command: { action: "enable" },
+  });
+
+  client.clear();
+});

--- a/src/hooks/use-server-command.ts
+++ b/src/hooks/use-server-command.ts
@@ -70,9 +70,10 @@ export function useServerCommand(scope: "blocking" | "maintenance") {
   async function retry(command: Command, targets: string[]) {
     if (command.action === "enable" || command.action === "disable") {
       try {
-        const statuses = await utils.servers.blockingStatus.fetch({
-          serverIds: targets,
-        });
+        const statuses = await utils.servers.blockingStatus.fetch(
+          { serverIds: targets },
+          { staleTime: 0 },
+        );
         const pending = statuses
           .filter((result) => {
             if (!result.success) {

--- a/src/hooks/use-server-command.ts
+++ b/src/hooks/use-server-command.ts
@@ -1,0 +1,110 @@
+"use client";
+
+import { toast } from "sonner";
+import { api, type RouterInputs } from "~/trpc/react";
+import { useDashboardServers } from "~/components/dashboard/server-context";
+
+type Command = RouterInputs["servers"]["command"]["command"];
+
+export function useServerCommand(scope: "blocking" | "maintenance") {
+  const dashboard = useDashboardServers();
+  const utils = api.useUtils();
+  const mutation = api.servers.command.useMutation();
+
+  async function execute(command: Command, targets?: string[]) {
+    const serverIds = targets ?? dashboard.selection.selected(scope);
+    try {
+      const results = await mutation.mutateAsync({ serverIds, command });
+      const failed = results.filter((result) => !result.success);
+      const succeeded = results.length - failed.length;
+      const names = (ids: string[]) =>
+        dashboard.servers
+          .filter((server) => ids.includes(server.id))
+          .map((server) => server.name)
+          .join(", ");
+      if (succeeded) {
+        toast.success(
+          `Completed on ${succeeded} ${succeeded === 1 ? "server" : "servers"}`,
+        );
+      }
+      if (failed.length) {
+        const uncertain = failed.some(
+          (result) => !result.success && result.error.kind === "timeout",
+        );
+        toast.error(
+          uncertain
+            ? "Some servers did not confirm the action"
+            : "Some actions failed",
+          {
+            description: [
+              names(failed.map((result) => result.serverId)),
+              command.action === "disable" && command.duration !== "0"
+                ? "Retrying restarts the blocking timer on these servers."
+                : undefined,
+            ]
+              .filter(Boolean)
+              .join(". "),
+            action: {
+              label: "Retry",
+              onClick: () =>
+                void retry(
+                  command,
+                  failed.map((result) => result.serverId),
+                ),
+            },
+          },
+        );
+      }
+    } catch (error) {
+      toast.error("Unable to complete the action", {
+        description: error instanceof Error ? error.message : undefined,
+      });
+    } finally {
+      await Promise.all([
+        utils.servers.blockingStatus.invalidate(),
+        utils.servers.statistics.invalidate(),
+      ]);
+    }
+  }
+
+  async function retry(command: Command, targets: string[]) {
+    if (command.action === "enable" || command.action === "disable") {
+      try {
+        const statuses = await utils.servers.blockingStatus.fetch({
+          serverIds: targets,
+        });
+        const pending = statuses
+          .filter((result) => {
+            if (!result.success) {
+              return true;
+            }
+            if (command.action === "enable") {
+              return !result.data.enabled;
+            }
+            return (
+              Boolean(command.groups) ||
+              command.duration !== "0" ||
+              result.data.enabled ||
+              Boolean(result.data.autoEnableInSec)
+            );
+          })
+          .map((result) => result.serverId);
+        if (!pending.length) {
+          toast.success("Blocking already matches on those servers");
+          return;
+        }
+        await execute(command, pending);
+        return;
+      } catch {
+        toast.error("Unable to check blocking status before retrying");
+        return;
+      }
+    }
+    await execute(command, targets);
+  }
+
+  return {
+    execute,
+    isPending: mutation.isPending,
+  };
+}

--- a/src/hooks/use-server-query.ts
+++ b/src/hooks/use-server-query.ts
@@ -1,0 +1,102 @@
+"use client";
+
+import { useId, useRef, useState } from "react";
+import { toast } from "sonner";
+import { useDashboardServers } from "~/components/dashboard/server-context";
+import { api, type RouterInputs, type RouterOutputs } from "~/trpc/react";
+
+type Query = RouterInputs["servers"]["query"];
+type Results = RouterOutputs["servers"]["query"];
+
+export function useServerQuery() {
+  const dashboard = useDashboardServers();
+  const mutation = api.servers.query.useMutation();
+  const notificationId = useId();
+  const generation = useRef(0);
+  const pending = useRef(false);
+  const [results, setResults] = useState<Results>([]);
+  const [names, setNames] = useState<Record<string, string>>({});
+
+  async function request(input: Query, current: number) {
+    if (pending.current || current !== generation.current) {
+      return;
+    }
+
+    pending.current = true;
+
+    try {
+      const next = await mutation.mutateAsync(input);
+
+      setResults((previous) => {
+        const updated = new Map(
+          next.map((result) => [result.serverId, result]),
+        );
+
+        return previous.length
+          ? previous.map((result) => updated.get(result.serverId) ?? result)
+          : next;
+      });
+
+      const failed = next.filter((result) => !result.success);
+
+      if (failed.length) {
+        toast.error("Some DNS queries failed", {
+          id: notificationId,
+          description: `${input.query} (${input.type})`,
+          action: {
+            label: "Retry",
+            onClick: () =>
+              void request(
+                {
+                  ...input,
+                  serverIds: failed.map((result) => result.serverId),
+                },
+                current,
+              ),
+          },
+        });
+      }
+    } catch (error) {
+      toast.error("Query failed", {
+        id: notificationId,
+        description: error instanceof Error ? error.message : undefined,
+        action: {
+          label: "Retry",
+          onClick: () => void request(input, current),
+        },
+      });
+    } finally {
+      pending.current = false;
+    }
+  }
+
+  function execute(input: Omit<Query, "serverIds">) {
+    if (pending.current) {
+      return;
+    }
+
+    generation.current++;
+    toast.dismiss(notificationId);
+    setResults([]);
+    setNames(
+      Object.fromEntries(
+        dashboard.servers.map((server) => [server.id, server.name]),
+      ),
+    );
+
+    void request(
+      { ...input, serverIds: dashboard.selection.selected("query") },
+      generation.current,
+    );
+  }
+
+  return {
+    execute,
+    results,
+    names,
+    isPending: mutation.isPending,
+    pendingServerIds: mutation.isPending
+      ? (mutation.variables?.serverIds ?? [])
+      : [],
+  };
+}

--- a/src/hooks/use-server-selection.ts
+++ b/src/hooks/use-server-selection.ts
@@ -1,0 +1,72 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+import { z } from "zod";
+
+const STORAGE_KEY = "blocky-ui.server-selection.v1";
+const CHANGE_EVENT = "blocky-ui:server-selection";
+const selectionSchema = z.object({
+  view: z.array(z.string()).default([]),
+  blocking: z.array(z.string()).default([]),
+  maintenance: z.array(z.string()).default([]),
+  query: z.array(z.string()).default([]),
+});
+type Scope = keyof z.infer<typeof selectionSchema>;
+let fallback: string | null = null;
+
+function subscribe(listener: () => void) {
+  window.addEventListener("storage", listener);
+  window.addEventListener(CHANGE_EVENT, listener);
+  return () => {
+    window.removeEventListener("storage", listener);
+    window.removeEventListener(CHANGE_EVENT, listener);
+  };
+}
+
+function snapshot() {
+  try {
+    return localStorage.getItem(STORAGE_KEY) ?? fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function parseSelection(raw: string | null) {
+  try {
+    const value: unknown = raw ? JSON.parse(raw) : {};
+    return selectionSchema.parse(value);
+  } catch {
+    return selectionSchema.parse({});
+  }
+}
+
+export function useServerSelection(ids: string[]) {
+  const raw = useSyncExternalStore(subscribe, snapshot, () => null);
+  const excluded = parseSelection(raw);
+
+  function selected(scope: Scope) {
+    const result = ids.filter((id) => !excluded[scope].includes(id));
+    return result.length ? result : ids.slice(0, 1);
+  }
+
+  function toggle(scope: Scope, id: string) {
+    const current = selected(scope);
+    if (current.length === 1 && current.includes(id)) {
+      return;
+    }
+    const next = current.includes(id)
+      ? current.filter((item) => item !== id)
+      : [...current, id];
+    const value = JSON.stringify({
+      ...excluded,
+      [scope]: ids.filter((item) => !next.includes(item)),
+    });
+    fallback = value;
+    try {
+      localStorage.setItem(STORAGE_KEY, value);
+    } catch {}
+    window.dispatchEvent(new Event(CHANGE_EVENT));
+  }
+
+  return { selected, toggle };
+}

--- a/src/lib/aggregate-statistics.test.ts
+++ b/src/lib/aggregate-statistics.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { aggregateStatistics } from "~/lib/aggregate-statistics";
+import { type RouterOutputs } from "~/trpc/react";
+
+type Result = RouterOutputs["servers"]["statistics"][number];
+
+function result(
+  serverId: string,
+  {
+    queries,
+    cached,
+    forwarded,
+    answered,
+    latency,
+  }: {
+    queries: number;
+    cached: number;
+    forwarded: number;
+    answered: number;
+    latency: number;
+  },
+): Result {
+  return {
+    serverId,
+    success: true,
+    data: {
+      answered,
+      summary: {
+        queries,
+        cached,
+        forwarded,
+        avgResponseMs: latency,
+        blocked: 0,
+        dropped: 0,
+        errors: queries - answered,
+        cacheHitRate: cached / (cached + forwarded),
+      },
+      overview: {
+        totalQueries: queries,
+        blocked: 0,
+        dropped: 0,
+        errors: queries - answered,
+        blockedPercentage: 0,
+        cacheHitRate: (cached / (cached + forwarded)) * 100,
+        listedDomains: 500,
+        avgResponseMs: latency,
+        cacheEntries: 100,
+        denylistGroups: 1,
+        allowlistDomains: 10,
+      },
+      topLists: { domains: [], blockedDomains: [], clients: [] },
+    },
+  };
+}
+
+describe("combined server statistics", () => {
+  it("weights cache rates by lookups and latency by answered queries", () => {
+    const summary = aggregateStatistics([
+      result("a", {
+        queries: 100,
+        cached: 90,
+        forwarded: 10,
+        answered: 100,
+        latency: 10,
+      }),
+      result("b", {
+        queries: 1000,
+        cached: 1,
+        forwarded: 9,
+        answered: 10,
+        latency: 100,
+      }),
+      {
+        serverId: "offline",
+        success: false,
+        error: { kind: "connection", message: "Unable to reach the server." },
+      },
+    ]);
+    expect(summary?.totalQueries).toBe(1100);
+    expect(summary?.cacheHitRate).toBeCloseTo((91 / 110) * 100);
+    expect(summary?.avgResponseMs).toBe(18);
+    expect(summary?.cacheEntries).toBe(200);
+    expect(summary).not.toHaveProperty("listedDomains");
+  });
+
+  it("does not turn missing statistics into zero traffic", () => {
+    expect(aggregateStatistics([])).toBeNull();
+  });
+});

--- a/src/lib/aggregate-statistics.ts
+++ b/src/lib/aggregate-statistics.ts
@@ -1,0 +1,51 @@
+import { type RouterOutputs } from "~/trpc/react";
+
+type StatisticsResult = RouterOutputs["servers"]["statistics"][number];
+
+export function aggregateStatistics(results: StatisticsResult[]) {
+  const available = results.flatMap((result) =>
+    result.success ? [result.data] : [],
+  );
+  if (!available.length) {
+    return null;
+  }
+  const totals = available.reduce(
+    (total, { summary, overview, answered }) => ({
+      queries: total.queries + summary.queries,
+      blocked: total.blocked + summary.blocked,
+      dropped: total.dropped + summary.dropped,
+      errors: total.errors + summary.errors,
+      cached: total.cached + summary.cached,
+      forwarded: total.forwarded + summary.forwarded,
+      duration: total.duration + summary.avgResponseMs * answered,
+      entries: total.entries + overview.cacheEntries,
+      answered: total.answered + answered,
+    }),
+    {
+      answered: 0,
+      queries: 0,
+      blocked: 0,
+      dropped: 0,
+      errors: 0,
+      cached: 0,
+      forwarded: 0,
+      duration: 0,
+      entries: 0,
+    },
+  );
+  const lookups = totals.cached + totals.forwarded;
+  return {
+    totalQueries: totals.queries,
+    blocked: totals.blocked,
+    dropped: totals.dropped,
+    errors: totals.errors,
+    blockedPercentage: totals.queries
+      ? (totals.blocked / totals.queries) * 100
+      : 0,
+    cacheHitRate: lookups ? (totals.cached / lookups) * 100 : 0,
+    avgResponseMs: totals.answered
+      ? Math.round(totals.duration / totals.answered)
+      : 0,
+    cacheEntries: totals.entries,
+  };
+}

--- a/src/trpc/react.tsx
+++ b/src/trpc/react.tsx
@@ -29,7 +29,6 @@ export const api = createTRPCReact<AppRouter>();
 /**
  * Inference helper for inputs.
  *
- * @knipignore
  * @example type HelloInput = RouterInputs['example']['hello']
  */
 export type RouterInputs = inferRouterInputs<AppRouter>;


### PR DESCRIPTION
Blocking controls, maintenance operations and the DNS query tool now have independent server targets. The overview combines live API statistics, shows mixed blocking states and exposes a per-server listed-domain breakdown without treating list sizes as unique domains.

Commands report partial failures through existing notifications. Retrying a blocking command reads fresh status first. DNS query results keep each server's response separate. The layout and loading states also work with one server.

Related to #395: live overview statistics remain API-based, while query history is handled by the log-source coordinator. Global history selection and YAML activation follow in the next PR.

Validated with aggregation and command-retry tests, static checks and a production build.

Part 5 of 7 in the multi-server stack. Review against `review/04-combined-query-history`.

## Screenshots

These captures show the controls added here, running with three demo servers in the completed stack. Demo configuration is introduced in #429.

Blocking targets Home and Office, with a mixed blocking state. Operations independently target all three servers.

![Independent blocking and operation targets, with mixed blocking status](https://github.com/user-attachments/assets/2121c29d-bb42-49f0-9ef2-01573c45adfe)

One DNS query sent to all three servers, with each response shown separately.

![DNS query targets and separate responses for Home, Office and Backup](https://github.com/user-attachments/assets/f366a72f-46bf-41e5-a052-14fb2da86ae5)
